### PR TITLE
DPR-529 removed issuer-uri from config

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -28,7 +28,6 @@ spring:
     oauth2:
       resourceserver:
         jwt:
-          issuer-uri: ${hmpps.auth.url}
           jwk-set-uri: ${hmpps.auth.url}/.well-known/jwks.json
     user:
       roles: ${AUTHORISED_ROLES}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -15,7 +15,6 @@ spring:
     oauth2:
       resourceserver:
         jwt:
-          issuer-uri: ${hmpps.auth.url}
           jwk-set-uri: ${hmpps.auth.url}/.well-known/jwks.json
     user:
       roles: ROLE_PRISONS_REPORTING_USER


### PR DESCRIPTION
Removed issuer-uri from the config as tokens that do not contain it cause an error.