### PR TITLE
Dpr 577 date filters

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/config/DigitalPrisonReportingMiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/config/DigitalPrisonReportingMiExceptionHandler.kt
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestControllerAdvice
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
+import java.time.format.DateTimeParseException
 
 @RestControllerAdvice
 class DigitalPrisonReportingMiExceptionHandler {
@@ -22,6 +23,11 @@ class DigitalPrisonReportingMiExceptionHandler {
   @Suppress("TYPE_MISMATCH")
   @ExceptionHandler(MethodArgumentTypeMismatchException::class)
   fun handleTypeMismatch(e: Exception): ResponseEntity<ErrorResponse> {
+    return respondWithBadRequest(e)
+  }
+
+  @ExceptionHandler(DateTimeParseException::class)
+  fun handleDateTimeParseException(e: Exception): ResponseEntity<ErrorResponse> {
     return respondWithBadRequest(e)
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/config/DigitalPrisonReportingMiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/config/DigitalPrisonReportingMiExceptionHandler.kt
@@ -10,7 +10,6 @@ import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestControllerAdvice
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
-import java.time.format.DateTimeParseException
 
 @RestControllerAdvice
 class DigitalPrisonReportingMiExceptionHandler {
@@ -23,11 +22,6 @@ class DigitalPrisonReportingMiExceptionHandler {
   @Suppress("TYPE_MISMATCH")
   @ExceptionHandler(MethodArgumentTypeMismatchException::class)
   fun handleTypeMismatch(e: Exception): ResponseEntity<ErrorResponse> {
-    return respondWithBadRequest(e)
-  }
-
-  @ExceptionHandler(DateTimeParseException::class)
-  fun handleDateTimeParseException(e: Exception): ResponseEntity<ErrorResponse> {
     return respondWithBadRequest(e)
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/controller/ExternalMovementsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/controller/ExternalMovementsController.kt
@@ -64,7 +64,7 @@ class ExternalMovementsController(val externalMovementService: ExternalMovementS
 
   private fun createFilterMap(direction: String?, startDate: LocalDate?, endDate: LocalDate?): Map<ExternalMovementFilter, Any> =
     buildMap {
-      direction?.trim()?.ifEmpty { null }?.let { put(DIRECTION, it) }
+      direction?.trim()?.let { if (it.isNotEmpty()) put(DIRECTION, it) }
       startDate?.let { put(START_DATE, it) }
       endDate?.let { put(END_DATE, it) }
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/controller/ExternalMovementsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/controller/ExternalMovementsController.kt
@@ -12,6 +12,8 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.model.Count
 import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.model.ExternalMovement
 import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.model.ExternalMovementFilter
 import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.model.ExternalMovementFilter.DIRECTION
+import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.model.ExternalMovementFilter.END_DATE
+import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.model.ExternalMovementFilter.START_DATE
 import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.service.ExternalMovementService
 
 @Validated
@@ -26,8 +28,10 @@ class ExternalMovementsController(val externalMovementService: ExternalMovementS
   )
   fun stubbedCount(
     @RequestParam direction: String?,
+    @RequestParam startDate: String?,
+    @RequestParam endDate: String?,
   ): Count {
-    return externalMovementService.count(createFilterMap(direction))
+    return externalMovementService.count(createFilterMap(direction, startDate, endDate))
   }
 
   @GetMapping("/external-movements")
@@ -45,20 +49,22 @@ class ExternalMovementsController(val externalMovementService: ExternalMovementS
     @RequestParam(defaultValue = "date") sortColumn: String,
     @RequestParam(defaultValue = "false") sortedAsc: Boolean,
     @RequestParam direction: String?,
+    @RequestParam startDate: String?,
+    @RequestParam endDate: String?,
   ): List<ExternalMovement> {
     return externalMovementService.list(
       selectedPage = selectedPage,
       pageSize = pageSize,
       sortColumn = sortColumn,
       sortedAsc = sortedAsc,
-      filters = createFilterMap(direction),
+      filters = createFilterMap(direction, startDate, endDate),
     )
   }
 
-  private fun createFilterMap(direction: String?): Map<ExternalMovementFilter, String> =
+  private fun createFilterMap(direction: String?, startDate: String?, endDate: String?): Map<ExternalMovementFilter, String> =
     buildMap {
-      if (!direction.isNullOrBlank()) {
-        put(DIRECTION, direction)
-      }
+      direction?.ifEmpty { null }?.let { put(DIRECTION, it) }
+      startDate?.ifEmpty { null }?.let { put(START_DATE, it) }
+      endDate?.ifEmpty { null }?.let { put(END_DATE, it) }
     }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/controller/ExternalMovementsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/controller/ExternalMovementsController.kt
@@ -15,6 +15,7 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.model.ExternalMovem
 import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.model.ExternalMovementFilter.END_DATE
 import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.model.ExternalMovementFilter.START_DATE
 import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.service.ExternalMovementService
+import java.time.LocalDate
 
 @Validated
 @RestController
@@ -28,8 +29,8 @@ class ExternalMovementsController(val externalMovementService: ExternalMovementS
   )
   fun stubbedCount(
     @RequestParam direction: String?,
-    @RequestParam startDate: String?,
-    @RequestParam endDate: String?,
+    @RequestParam startDate: LocalDate?,
+    @RequestParam endDate: LocalDate?,
   ): Count {
     return externalMovementService.count(createFilterMap(direction, startDate, endDate))
   }
@@ -49,8 +50,8 @@ class ExternalMovementsController(val externalMovementService: ExternalMovementS
     @RequestParam(defaultValue = "date") sortColumn: String,
     @RequestParam(defaultValue = "false") sortedAsc: Boolean,
     @RequestParam direction: String?,
-    @RequestParam startDate: String?,
-    @RequestParam endDate: String?,
+    @RequestParam startDate: LocalDate?,
+    @RequestParam endDate: LocalDate?,
   ): List<ExternalMovement> {
     return externalMovementService.list(
       selectedPage = selectedPage,
@@ -61,10 +62,10 @@ class ExternalMovementsController(val externalMovementService: ExternalMovementS
     )
   }
 
-  private fun createFilterMap(direction: String?, startDate: String?, endDate: String?): Map<ExternalMovementFilter, String> =
+  private fun createFilterMap(direction: String?, startDate: LocalDate?, endDate: LocalDate?): Map<ExternalMovementFilter, Any> =
     buildMap {
-      direction?.ifEmpty { null }?.let { put(DIRECTION, it) }
-      startDate?.ifEmpty { null }?.let { put(START_DATE, it) }
-      endDate?.ifEmpty { null }?.let { put(END_DATE, it) }
+      direction?.trim()?.ifEmpty { null }?.let { put(DIRECTION, it) }
+      startDate?.let { put(START_DATE, it) }
+      endDate?.let { put(END_DATE, it) }
     }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/data/FakeExternalMovementRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/data/FakeExternalMovementRepository.kt
@@ -15,7 +15,7 @@ import java.time.LocalDate
 @Service
 class FakeExternalMovementRepository {
 
-  fun list(selectedPage: Long, pageSize: Long, sortColumn: String, sortedAsc: Boolean, filters: Map<ExternalMovementFilter, String>): List<ExternalMovement> {
+  fun list(selectedPage: Long, pageSize: Long, sortColumn: String, sortedAsc: Boolean, filters: Map<ExternalMovementFilter, Any>): List<ExternalMovement> {
     return readExternalMovementsFromFile()
       .filter { matchesFilters(it, filters) }
       .let {
@@ -43,7 +43,7 @@ class FakeExternalMovementRepository {
     return if (!sortedAsc) allExternalMovementsSorted.reversed() else allExternalMovementsSorted
   }
 
-  fun count(filters: Map<ExternalMovementFilter, String>): Long {
+  fun count(filters: Map<ExternalMovementFilter, Any>): Long {
     return readExternalMovementsFromFile().count { matchesFilters(it, filters) }.toLong()
   }
 
@@ -55,8 +55,8 @@ class FakeExternalMovementRepository {
       ?.let { mapper.readValue<List<ExternalMovement>>(it) } ?: emptyList()
   }
 
-  private fun matchesFilters(externalMovement: ExternalMovement, filters: Map<ExternalMovementFilter, String>): Boolean =
+  private fun matchesFilters(externalMovement: ExternalMovement, filters: Map<ExternalMovementFilter, Any>): Boolean =
     filters[DIRECTION]?.equals(externalMovement.direction.lowercase()) ?: true &&
-      filters[START_DATE]?.let { LocalDate.parse(it) }?.let { it.isEqual(externalMovement.date) || it.isBefore(externalMovement.date) } ?: true &&
-      filters[END_DATE]?.let { LocalDate.parse(it) }?.let { it.isEqual(externalMovement.date) || it.isAfter(externalMovement.date) } ?: true
+      filters[START_DATE]?.let { it as LocalDate }?.let { it.isEqual(externalMovement.date) || it.isBefore(externalMovement.date) } ?: true &&
+      filters[END_DATE]?.let { it as LocalDate }?.let { it.isEqual(externalMovement.date) || it.isAfter(externalMovement.date) } ?: true
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/data/FakeExternalMovementRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/data/FakeExternalMovementRepository.kt
@@ -8,6 +8,9 @@ import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.model.ExternalMovement
 import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.model.ExternalMovementFilter
 import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.model.ExternalMovementFilter.DIRECTION
+import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.model.ExternalMovementFilter.END_DATE
+import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.model.ExternalMovementFilter.START_DATE
+import java.time.LocalDate
 
 @Service
 class FakeExternalMovementRepository {
@@ -47,11 +50,13 @@ class FakeExternalMovementRepository {
   private fun readExternalMovementsFromFile(): List<ExternalMovement> {
     val mapper = jacksonObjectMapper()
     mapper.registerModule(JavaTimeModule())
-    return this::class.java.classLoader.getResource("fakeExternalMovementsData.json")!!
-      .readText()
-      .let { mapper.readValue<List<ExternalMovement>>(it) }
+    return this::class.java.classLoader.getResource("fakeExternalMovementsData.json")
+      ?.readText()
+      ?.let { mapper.readValue<List<ExternalMovement>>(it) } ?: emptyList()
   }
 
-  private fun matchesFilters(it: ExternalMovement, filters: Map<ExternalMovementFilter, String>): Boolean =
-    filters[DIRECTION]?.equals(it.direction.lowercase()) ?: true
+  private fun matchesFilters(externalMovement: ExternalMovement, filters: Map<ExternalMovementFilter, String>): Boolean =
+    filters[DIRECTION]?.equals(externalMovement.direction.lowercase()) ?: true &&
+      filters[START_DATE]?.let { LocalDate.parse(it).isBefore(externalMovement.date) } ?: true &&
+      filters[END_DATE]?.let { LocalDate.parse(it).isAfter(externalMovement.date) } ?: true
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/data/FakeExternalMovementRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/data/FakeExternalMovementRepository.kt
@@ -57,6 +57,6 @@ class FakeExternalMovementRepository {
 
   private fun matchesFilters(externalMovement: ExternalMovement, filters: Map<ExternalMovementFilter, String>): Boolean =
     filters[DIRECTION]?.equals(externalMovement.direction.lowercase()) ?: true &&
-      filters[START_DATE]?.let { LocalDate.parse(it).isBefore(externalMovement.date) } ?: true &&
-      filters[END_DATE]?.let { LocalDate.parse(it).isAfter(externalMovement.date) } ?: true
+      filters[START_DATE]?.let { LocalDate.parse(it) }?.let { it.isEqual(externalMovement.date) || it.isBefore(externalMovement.date) } ?: true &&
+      filters[END_DATE]?.let { LocalDate.parse(it) }?.let { it.isEqual(externalMovement.date) || it.isAfter(externalMovement.date) } ?: true
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/model/ExternalMovementFilter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/model/ExternalMovementFilter.kt
@@ -1,4 +1,7 @@
 package uk.gov.justice.digital.hmpps.digitalprisonreportingmi.model
 enum class ExternalMovementFilter {
-  DIRECTION, ;
+  DIRECTION,
+  START_DATE,
+  END_DATE,
+  ;
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/service/ExternalMovementService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/service/ExternalMovementService.kt
@@ -9,11 +9,11 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.model.ExternalMovem
 @Service
 data class ExternalMovementService(val fakeExternalMovementRepository: FakeExternalMovementRepository) {
 
-  fun list(selectedPage: Long, pageSize: Long, sortColumn: String, sortedAsc: Boolean, filters: Map<ExternalMovementFilter, String>): List<ExternalMovement> {
+  fun list(selectedPage: Long, pageSize: Long, sortColumn: String, sortedAsc: Boolean, filters: Map<ExternalMovementFilter, Any>): List<ExternalMovement> {
     return fakeExternalMovementRepository.list(selectedPage, pageSize, sortColumn, sortedAsc, filters)
   }
 
-  fun count(filters: Map<ExternalMovementFilter, String>): Count {
+  fun count(filters: Map<ExternalMovementFilter, Any>): Count {
     return Count(fakeExternalMovementRepository.count(filters))
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/data/FakeExternalMovementRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/data/FakeExternalMovementRepositoryTest.kt
@@ -124,73 +124,73 @@ class FakeExternalMovementRepositoryTest {
 
   @Test
   fun `should return a count of movements with a startDate filter`() {
-    val actual = externalMovementRepository.count(singletonMap(START_DATE, "2023-05-01"))
+    val actual = externalMovementRepository.count(singletonMap(START_DATE, LocalDate.parse("2023-05-01")))
     assertEquals(2, actual)
   }
 
   @Test
   fun `should return a count of movements with a endDate filter`() {
-    val actual = externalMovementRepository.count(singletonMap(END_DATE, "2023-01-31"))
+    val actual = externalMovementRepository.count(singletonMap(END_DATE, LocalDate.parse("2023-01-31")))
     assertEquals(1, actual)
   }
 
   @Test
   fun `should return a count of movements with a startDate and an endDate filter`() {
-    val actual = externalMovementRepository.count(mapOf(START_DATE to "2023-04-30", END_DATE to "2023-05-01"))
+    val actual = externalMovementRepository.count(mapOf(START_DATE to LocalDate.parse("2023-04-30"), END_DATE to LocalDate.parse("2023-05-01")))
     assertEquals(2, actual)
   }
 
   @Test
   fun `should return a count of zero with a startDate greater than the latest movement date`() {
-    val actual = externalMovementRepository.count(mapOf(START_DATE to "2025-04-30"))
+    val actual = externalMovementRepository.count(mapOf(START_DATE to LocalDate.parse("2025-04-30")))
     assertEquals(0, actual)
   }
 
   @Test
   fun `should return a count of zero with an endDate less than the earliest movement date`() {
-    val actual = externalMovementRepository.count(mapOf(END_DATE to "2019-04-30"))
+    val actual = externalMovementRepository.count(mapOf(END_DATE to LocalDate.parse("2019-04-30")))
     assertEquals(0, actual)
   }
 
   @Test
   fun `should return a count of zero if the start date is after the end date`() {
-    val actual = externalMovementRepository.count(mapOf(START_DATE to "2023-04-30", END_DATE to "2019-05-01"))
+    val actual = externalMovementRepository.count(mapOf(START_DATE to LocalDate.parse("2023-04-30"), END_DATE to LocalDate.parse("2019-05-01")))
     assertEquals(0, actual)
   }
 
   @Test
   fun `should return all the movements on or after the provided start date`() {
-    val actual = externalMovementRepository.list(1, 10, "date", false, singletonMap(START_DATE, "2023-04-30"))
+    val actual = externalMovementRepository.list(1, 10, "date", false, singletonMap(START_DATE, LocalDate.parse("2023-04-30")))
     assertEquals(listOf(externalMovement5, externalMovement4, externalMovement3), actual)
   }
 
   @Test
   fun `should return all the movements on or before the provided end date`() {
-    val actual = externalMovementRepository.list(1, 10, "date", false, singletonMap(END_DATE, "2023-04-25"))
+    val actual = externalMovementRepository.list(1, 10, "date", false, singletonMap(END_DATE, LocalDate.parse("2023-04-25")))
     assertEquals(listOf(externalMovement2, externalMovement1), actual)
   }
 
   @Test
   fun `should return all the movements between the provided start and end dates`() {
-    val actual = externalMovementRepository.list(1, 10, "date", false, mapOf(START_DATE to "2023-04-25", END_DATE to "2023-05-20"))
+    val actual = externalMovementRepository.list(1, 10, "date", false, mapOf(START_DATE to LocalDate.parse("2023-04-25"), END_DATE to LocalDate.parse("2023-05-20")))
     assertEquals(listOf(externalMovement5, externalMovement4, externalMovement3, externalMovement2), actual)
   }
 
   @Test
   fun `should return no movements if the start date is after the latest movement date`() {
-    val actual = externalMovementRepository.list(1, 10, "date", false, singletonMap(START_DATE, "2025-01-01"))
+    val actual = externalMovementRepository.list(1, 10, "date", false, singletonMap(START_DATE, LocalDate.parse("2025-01-01")))
     assertEquals(emptyList<ExternalMovement>(), actual)
   }
 
   @Test
   fun `should return no movements if the end date is before the earliest movement date`() {
-    val actual = externalMovementRepository.list(1, 10, "date", false, singletonMap(END_DATE, "2015-01-01"))
+    val actual = externalMovementRepository.list(1, 10, "date", false, singletonMap(END_DATE, LocalDate.parse("2015-01-01")))
     assertEquals(emptyList<ExternalMovement>(), actual)
   }
 
   @Test
   fun `should return no movements if the start date is after the end date`() {
-    val actual = externalMovementRepository.list(1, 10, "date", false, mapOf(START_DATE to "2023-05-01", END_DATE to "2023-04-25"))
+    val actual = externalMovementRepository.list(1, 10, "date", false, mapOf(START_DATE to LocalDate.parse("2023-05-01"), END_DATE to LocalDate.parse("2023-04-25")))
     assertEquals(emptyList<ExternalMovement>(), actual)
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/data/FakeExternalMovementRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/data/FakeExternalMovementRepositoryTest.kt
@@ -123,37 +123,37 @@ class FakeExternalMovementRepositoryTest {
   }
 
   @Test
-  fun `should return all the movements after the provided start date`() {
+  fun `should return all the movements on or after the provided start date`() {
     val actual = externalMovementRepository.list(1, 10, "date", false, singletonMap(START_DATE, "2023-04-30"))
-    assertEquals(listOf(externalMovement5, externalMovement4), actual)
+    assertEquals(listOf(externalMovement5, externalMovement4, externalMovement3), actual)
   }
 
   @Test
-  fun `should return all the movements before the provided end date`() {
+  fun `should return all the movements on or before the provided end date`() {
     val actual = externalMovementRepository.list(1, 10, "date", false, singletonMap(END_DATE, "2023-04-25"))
-    assertEquals(listOf(externalMovement1), actual)
+    assertEquals(listOf(externalMovement2, externalMovement1), actual)
   }
 
   @Test
   fun `should return all the movements between the provided start and end dates`() {
     val actual = externalMovementRepository.list(1, 10, "date", false, mapOf(START_DATE to "2023-04-25", END_DATE to "2023-05-20"))
-    assertEquals(listOf(externalMovement4, externalMovement3), actual)
+    assertEquals(listOf(externalMovement5, externalMovement4, externalMovement3, externalMovement2), actual)
   }
 
   @Test
-  fun `should retund no movements if the start date is after the latest movement date`() {
+  fun `should return no movements if the start date is after the latest movement date`() {
     val actual = externalMovementRepository.list(1, 10, "date", false, singletonMap(START_DATE, "2025-01-01"))
     assertEquals(emptyList<ExternalMovement>(), actual)
   }
 
   @Test
-  fun `should retund no movements if the end date is before the earliest movement date`() {
+  fun `should return no movements if the end date is before the earliest movement date`() {
     val actual = externalMovementRepository.list(1, 10, "date", false, singletonMap(END_DATE, "2015-01-01"))
     assertEquals(emptyList<ExternalMovement>(), actual)
   }
 
   @Test
-  fun `should retund no movements if the start date is after the end date`() {
+  fun `should return no movements if the start date is after the end date`() {
     val actual = externalMovementRepository.list(1, 10, "date", false, mapOf(START_DATE to "2023-05-01", END_DATE to "2023-04-25"))
     assertEquals(emptyList<ExternalMovement>(), actual)
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/data/FakeExternalMovementRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/data/FakeExternalMovementRepositoryTest.kt
@@ -123,6 +123,41 @@ class FakeExternalMovementRepositoryTest {
   }
 
   @Test
+  fun `should return a count of movements with a startDate filter`() {
+    val actual = externalMovementRepository.count(singletonMap(START_DATE, "2023-05-01"))
+    assertEquals(2, actual)
+  }
+
+  @Test
+  fun `should return a count of movements with a endDate filter`() {
+    val actual = externalMovementRepository.count(singletonMap(END_DATE, "2023-01-31"))
+    assertEquals(1, actual)
+  }
+
+  @Test
+  fun `should return a count of movements with a startDate and an endDate filter`() {
+    val actual = externalMovementRepository.count(mapOf(START_DATE to "2023-04-30", END_DATE to "2023-05-01"))
+    assertEquals(2, actual)
+  }
+  @Test
+  fun `should return a count of zero with a startDate greater than the latest movement date`() {
+    val actual = externalMovementRepository.count(mapOf(START_DATE to "2025-04-30"))
+    assertEquals(0, actual)
+  }
+
+  @Test
+  fun `should return a count of zero with an endDate less than the earliest movement date`() {
+    val actual = externalMovementRepository.count(mapOf(END_DATE to "2019-04-30"))
+    assertEquals(0, actual)
+  }
+
+  @Test
+  fun `should return a count of zero if the start date is after the end date`() {
+    val actual = externalMovementRepository.count(mapOf(START_DATE to "2023-04-30", END_DATE to "2019-05-01"))
+    assertEquals(0, actual)
+  }
+
+  @Test
   fun `should return all the movements on or after the provided start date`() {
     val actual = externalMovementRepository.list(1, 10, "date", false, singletonMap(START_DATE, "2023-04-30"))
     assertEquals(listOf(externalMovement5, externalMovement4, externalMovement3), actual)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/data/FakeExternalMovementRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/data/FakeExternalMovementRepositoryTest.kt
@@ -139,6 +139,7 @@ class FakeExternalMovementRepositoryTest {
     val actual = externalMovementRepository.count(mapOf(START_DATE to "2023-04-30", END_DATE to "2023-05-01"))
     assertEquals(2, actual)
   }
+
   @Test
   fun `should return a count of zero with a startDate greater than the latest movement date`() {
     val actual = externalMovementRepository.count(mapOf(START_DATE to "2025-04-30"))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/data/FakeExternalMovementRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/data/FakeExternalMovementRepositoryTest.kt
@@ -11,6 +11,8 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.FakeExternalMo
 import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.FakeExternalMovementRepositoryTest.AllMovements.externalMovement5
 import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.model.ExternalMovement
 import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.model.ExternalMovementFilter.DIRECTION
+import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.model.ExternalMovementFilter.END_DATE
+import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.model.ExternalMovementFilter.START_DATE
 import java.time.LocalDate
 import java.time.LocalTime
 import java.util.Collections.singletonMap
@@ -118,6 +120,42 @@ class FakeExternalMovementRepositoryTest {
   fun `should return a count of outwards movements with an out direction filter`() {
     val actual = externalMovementRepository.count(singletonMap(DIRECTION, "out"))
     assertEquals(1L, actual)
+  }
+
+  @Test
+  fun `should return all the movements after the provided start date`() {
+    val actual = externalMovementRepository.list(1, 10, "date", false, singletonMap(START_DATE, "2023-04-30"))
+    assertEquals(listOf(externalMovement5, externalMovement4), actual)
+  }
+
+  @Test
+  fun `should return all the movements before the provided end date`() {
+    val actual = externalMovementRepository.list(1, 10, "date", false, singletonMap(END_DATE, "2023-04-25"))
+    assertEquals(listOf(externalMovement1), actual)
+  }
+
+  @Test
+  fun `should return all the movements between the provided start and end dates`() {
+    val actual = externalMovementRepository.list(1, 10, "date", false, mapOf(START_DATE to "2023-04-25", END_DATE to "2023-05-20"))
+    assertEquals(listOf(externalMovement4, externalMovement3), actual)
+  }
+
+  @Test
+  fun `should retund no movements if the start date is after the latest movement date`() {
+    val actual = externalMovementRepository.list(1, 10, "date", false, singletonMap(START_DATE, "2025-01-01"))
+    assertEquals(emptyList<ExternalMovement>(), actual)
+  }
+
+  @Test
+  fun `should retund no movements if the end date is before the earliest movement date`() {
+    val actual = externalMovementRepository.list(1, 10, "date", false, singletonMap(END_DATE, "2015-01-01"))
+    assertEquals(emptyList<ExternalMovement>(), actual)
+  }
+
+  @Test
+  fun `should retund no movements if the start date is after the end date`() {
+    val actual = externalMovementRepository.list(1, 10, "date", false, mapOf(START_DATE to "2023-05-01", END_DATE to "2023-04-25"))
+    assertEquals(emptyList<ExternalMovement>(), actual)
   }
 
   private fun assertExternalMovements(sortColumn: String, expectedForAscending: ExternalMovement, expectedForDescending: ExternalMovement): List<DynamicTest> {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/integration/ExternalMovementsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/integration/ExternalMovementsIntegrationTest.kt
@@ -151,6 +151,41 @@ class ExternalMovementsIntegrationTest : IntegrationTestBase() {
   fun `External movements returns 400 for invalid sortedAsc query param`() {
     requestWithQueryAndAssert400("sortedAsc", "abc")
   }
+
+  @Test
+  fun `External movements returns 400 for invalid startDate query param`() {
+    requestWithQueryAndAssert400("startDate", "abc")
+  }
+
+  @Test
+  fun `External movements returns 400 for invalid endDate query param`() {
+    requestWithQueryAndAssert400("endDate", " ")
+  }
+
+  @Test
+  fun `External movements returns stubbed value matching the filters provided`() {
+    webTestClient.get()
+      .uri { uriBuilder: UriBuilder ->
+        uriBuilder
+          .path("/external-movements")
+          .queryParam("startDate", "2023-04-25")
+          .queryParam("endDate", "2023-05-20")
+          .queryParam("direction", "out")
+          .build()
+      }
+      .headers(setAuthorisation(roles = listOf(authorisedRole)))
+      .exchange()
+      .expectStatus()
+      .isOk()
+      .expectBody()
+      .json(
+        """[
+         {"prisonNumber": "Z966YYY", "date": "2023-05-01", "time": "15:19:00", "from": "Cardiff", "to": "Maidstone", "direction": "Out", "type": "Transfer", "reason": "Transfer Out to Other Establishment"}
+      ]       
+      """,
+      )
+  }
+
   private fun requestWithQueryAndAssert400(paramName: String, paramValue: Any) {
     webTestClient.get()
       .uri { uriBuilder: UriBuilder ->

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/integration/ExternalMovementsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/integration/ExternalMovementsIntegrationTest.kt
@@ -159,7 +159,7 @@ class ExternalMovementsIntegrationTest : IntegrationTestBase() {
 
   @Test
   fun `External movements returns 400 for invalid endDate query param`() {
-    requestWithQueryAndAssert400("endDate", " ", "/external-movements")
+    requestWithQueryAndAssert400("endDate", "b", "/external-movements")
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/integration/ExternalMovementsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/integration/ExternalMovementsIntegrationTest.kt
@@ -129,37 +129,47 @@ class ExternalMovementsIntegrationTest : IntegrationTestBase() {
 
   @Test
   fun `External movements returns 400 for invalid selectedPage query param`() {
-    requestWithQueryAndAssert400("selectedPage", 0)
+    requestWithQueryAndAssert400("selectedPage", 0, "/external-movements")
   }
 
   @Test
   fun `External movements returns 400 for invalid pageSize query param`() {
-    requestWithQueryAndAssert400("pageSize", 0)
+    requestWithQueryAndAssert400("pageSize", 0, "/external-movements")
   }
 
   @Test
   fun `External movements returns 400 for invalid (wrong type) pageSize query param`() {
-    requestWithQueryAndAssert400("pageSize", "a")
+    requestWithQueryAndAssert400("pageSize", "a", "/external-movements")
   }
 
   @Test
   fun `External movements returns 400 for invalid sortColumn query param`() {
-    requestWithQueryAndAssert400("sortColumn", "nonExistentColumn")
+    requestWithQueryAndAssert400("sortColumn", "nonExistentColumn", "/external-movements")
   }
 
   @Test
   fun `External movements returns 400 for invalid sortedAsc query param`() {
-    requestWithQueryAndAssert400("sortedAsc", "abc")
+    requestWithQueryAndAssert400("sortedAsc", "abc", "/external-movements")
   }
 
   @Test
   fun `External movements returns 400 for invalid startDate query param`() {
-    requestWithQueryAndAssert400("startDate", "abc")
+    requestWithQueryAndAssert400("startDate", "abc", "/external-movements")
   }
 
   @Test
   fun `External movements returns 400 for invalid endDate query param`() {
-    requestWithQueryAndAssert400("endDate", " ")
+    requestWithQueryAndAssert400("endDate", " ", "/external-movements")
+  }
+
+  @Test
+  fun `External movements count returns 400 for invalid startDate query param`() {
+    requestWithQueryAndAssert400("startDate", "a", "/external-movements/count")
+  }
+
+  @Test
+  fun `External movements count returns 400 for invalid endDate query param`() {
+    requestWithQueryAndAssert400("endDate", "17-12-2050", "/external-movements/count")
   }
 
   @Test
@@ -186,11 +196,11 @@ class ExternalMovementsIntegrationTest : IntegrationTestBase() {
       )
   }
 
-  private fun requestWithQueryAndAssert400(paramName: String, paramValue: Any) {
+  private fun requestWithQueryAndAssert400(paramName: String, paramValue: Any, path: String) {
     webTestClient.get()
       .uri { uriBuilder: UriBuilder ->
         uriBuilder
-          .path("/external-movements")
+          .path(path)
           .queryParam(paramName, paramValue)
           .build()
       }


### PR DESCRIPTION
This is the API side of the date filter.
The /external-movements and external-movements/count endpoints now accept two new optional query parameters, "startDate" and "endDate" in the form of "yyyy-mm-dd".
Both of the start and endDate are inclusive.
