### PR TITLE
Dpr 632 - Added Prisoner Name to The API response

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/controller/ExternalMovementsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/controller/ExternalMovementsController.kt
@@ -28,7 +28,7 @@ class ExternalMovementsController(val externalMovementService: ExternalMovementS
     description = "Gets a count of external movements (mocked)",
     security = [ SecurityRequirement(name = "bearer-jwt") ],
   )
-  fun stubbedCount(
+  fun count(
     @RequestParam direction: String?,
     @Parameter(description = "The start date (inclusive) from which to filter, in the format of yyyy-mm-dd.", example = "2023-04-25")
     @RequestParam

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/data/ExternalMovementPrisonerEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/data/ExternalMovementPrisonerEntity.kt
@@ -1,0 +1,17 @@
+package uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data
+
+import java.time.LocalDateTime
+
+data class ExternalMovementPrisonerEntity(
+  val id: Long,
+  val prisoner: Long,
+  val firstName: String,
+  val lastName: String,
+  val date: LocalDateTime,
+  val time: LocalDateTime,
+  val origin: String?,
+  val destination: String?,
+  val direction: String?,
+  val type: String,
+  val reason: String,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/data/ExternalMovementRepositoryCustom.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/data/ExternalMovementRepositoryCustom.kt
@@ -4,6 +4,6 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.model.ExternalMovem
 
 interface ExternalMovementRepositoryCustom {
 
-  fun list(selectedPage: Long, pageSize: Long, sortColumn: String, sortedAsc: Boolean, filters: Map<ExternalMovementFilter, Any>): List<ExternalMovementEntity>
+  fun list(selectedPage: Long, pageSize: Long, sortColumn: String, sortedAsc: Boolean, filters: Map<ExternalMovementFilter, Any>): List<ExternalMovementPrisonerEntity>
   fun count(filters: Map<ExternalMovementFilter, Any>): Long
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/model/ExternalMovementModel.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/model/ExternalMovementModel.kt
@@ -7,6 +7,8 @@ data class ExternalMovementModel(
   val id: Long,
   // This is the "prisoner" column in Redshift. Keeping is as prisonNumber for not breaking the UI for now and will change in the future.
   val prisonNumber: String,
+  val firstName: String,
+  val lastName: String,
   val date: LocalDate,
   val time: LocalTime,
   val from: String?,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/service/ExternalMovementService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/service/ExternalMovementService.kt
@@ -2,7 +2,7 @@ package uk.gov.justice.digital.hmpps.digitalprisonreportingmi.service
 
 import jakarta.validation.ValidationException
 import org.springframework.stereotype.Service
-import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.ExternalMovementEntity
+import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.ExternalMovementPrisonerEntity
 import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.ExternalMovementRepository
 import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.model.Count
 import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.model.ExternalMovementFilter
@@ -19,8 +19,11 @@ data class ExternalMovementService(val externalMovementRepository: ExternalMovem
     return Count(externalMovementRepository.count(filters))
   }
 
-  private fun toModel(entity: ExternalMovementEntity): ExternalMovementModel {
-    return ExternalMovementModel(entity.id, entity.prisoner.toString(), entity.date.toLocalDate(), entity.time.toLocalTime(), entity.origin, entity.destination, entity.direction, entity.type, entity.reason)
+  private fun toModel(entity: ExternalMovementPrisonerEntity): ExternalMovementModel {
+    return ExternalMovementModel(
+      entity.id, entity.prisoner.toString(), entity.firstName, entity.lastName,
+      entity.date.toLocalDate(), entity.time.toLocalTime(), entity.origin, entity.destination, entity.direction, entity.type, entity.reason,
+    )
   }
 
   private fun validateAndMapSortColumn(sortColumn: String): String {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/data/ExternalMovementRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/data/ExternalMovementRepositoryTest.kt
@@ -8,7 +8,13 @@ import org.junit.jupiter.api.TestFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
+import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.ExternalMovementRepositoryTest.AllMovementPrisoners.movementPrisoner1
+import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.ExternalMovementRepositoryTest.AllMovementPrisoners.movementPrisoner2
+import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.ExternalMovementRepositoryTest.AllMovementPrisoners.movementPrisoner3
+import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.ExternalMovementRepositoryTest.AllMovementPrisoners.movementPrisoner4
+import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.ExternalMovementRepositoryTest.AllMovementPrisoners.movementPrisoner5
 import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.ExternalMovementRepositoryTest.AllMovements.allExternalMovements
+import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.ExternalMovementRepositoryTest.AllPrisoners.allPrisoners
 import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.model.ExternalMovementFilter
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -21,31 +27,37 @@ class ExternalMovementRepositoryTest {
   @Autowired
   lateinit var externalMovementRepository: ExternalMovementRepository
 
+  @Autowired
+  lateinit var prisonerRepository: PrisonerRepository
+
   @BeforeEach
   fun setup() {
     allExternalMovements.forEach {
       externalMovementRepository.save(it)
+    }
+    allPrisoners.forEach {
+      prisonerRepository.save(it)
     }
   }
 
   @Test
   fun `should return 2 external movements for the selected page 2 and pageSize 2 sorted by date in ascending order`() {
     val actual = externalMovementRepository.list(2, 2, "date", true, emptyMap())
-    Assertions.assertEquals(listOf(AllMovements.externalMovement3, AllMovements.externalMovement4), actual)
+    Assertions.assertEquals(listOf(movementPrisoner3, movementPrisoner4), actual)
     Assertions.assertEquals(2, actual.size)
   }
 
   @Test
   fun `should return 1 external movement for the selected page 3 and pageSize 2 sorted by date in ascending order`() {
     val actual = externalMovementRepository.list(3, 2, "date", true, emptyMap())
-    Assertions.assertEquals(listOf(AllMovements.externalMovement5), actual)
+    Assertions.assertEquals(listOf(movementPrisoner5), actual)
     Assertions.assertEquals(1, actual.size)
   }
 
   @Test
   fun `should return 5 external movements for the selected page 1 and pageSize 5 sorted by date in ascending order`() {
     val actual = externalMovementRepository.list(1, 5, "date", true, emptyMap())
-    Assertions.assertEquals(listOf(AllMovements.externalMovement1, AllMovements.externalMovement2, AllMovements.externalMovement3, AllMovements.externalMovement4, AllMovements.externalMovement5), actual)
+    Assertions.assertEquals(listOf(movementPrisoner1, movementPrisoner2, movementPrisoner3, movementPrisoner4, movementPrisoner5), actual)
     Assertions.assertEquals(5, actual.size)
   }
 
@@ -63,35 +75,35 @@ class ExternalMovementRepositoryTest {
 
   @TestFactory
   fun `should return all external movements for the selected page and pageSize sorted by date when sortedAsc is true and when it is false`() =
-    assertExternalMovements(sortColumn = "date", expectedForAscending = AllMovements.externalMovement1, expectedForDescending = AllMovements.externalMovement5)
+    assertExternalMovements(sortColumn = "date", expectedForAscending = movementPrisoner1, expectedForDescending = movementPrisoner5)
 
   @TestFactory
   fun `should return all external movements for the selected page and pageSize sorted by time when sortedAsc is true and when it is false`() =
-    assertExternalMovements(sortColumn = "timeOnly", expectedForAscending = AllMovements.externalMovement1, expectedForDescending = AllMovements.externalMovement4)
+    assertExternalMovements(sortColumn = "timeOnly", expectedForAscending = movementPrisoner1, expectedForDescending = movementPrisoner4)
 
   @TestFactory
   fun `should return all external movements for the selected page and pageSize sorted by prisoner when sortedAsc is true and when it is false`() =
-    assertExternalMovements(sortColumn = "prisoner", expectedForAscending = AllMovements.externalMovement3, expectedForDescending = AllMovements.externalMovement1)
+    assertExternalMovements(sortColumn = "prisoner", expectedForAscending = movementPrisoner3, expectedForDescending = movementPrisoner1)
 
   @TestFactory
   fun `should return all external movements for the selected page and pageSize sorted by 'origin' when sortedAsc is true and when it is false`() =
-    assertExternalMovements(sortColumn = "origin", expectedForAscending = AllMovements.externalMovement4, expectedForDescending = AllMovements.externalMovement3)
+    assertExternalMovements(sortColumn = "origin", expectedForAscending = movementPrisoner4, expectedForDescending = movementPrisoner3)
 
   @TestFactory
   fun `should return all external movements for the selected page and pageSize sorted by 'destination' when sortedAsc is true and when it is false`() =
-    assertExternalMovements(sortColumn = "destination", expectedForAscending = AllMovements.externalMovement3, expectedForDescending = AllMovements.externalMovement2)
+    assertExternalMovements(sortColumn = "destination", expectedForAscending = movementPrisoner3, expectedForDescending = movementPrisoner2)
 
   @TestFactory
   fun `should return all external movements for the selected page and pageSize sorted by 'direction' when sortedAsc is true and when it is false`() =
-    assertExternalMovements(sortColumn = "direction", expectedForAscending = AllMovements.externalMovement1, expectedForDescending = AllMovements.externalMovement4)
+    assertExternalMovements(sortColumn = "direction", expectedForAscending = movementPrisoner1, expectedForDescending = movementPrisoner4)
 
   @TestFactory
   fun `should return all external movements for the selected page and pageSize sorted by 'type' when sortedAsc is true and when it is false`() =
-    assertExternalMovements(sortColumn = "type", expectedForAscending = AllMovements.externalMovement1, expectedForDescending = AllMovements.externalMovement2)
+    assertExternalMovements(sortColumn = "type", expectedForAscending = movementPrisoner1, expectedForDescending = movementPrisoner2)
 
   @TestFactory
   fun `should return all external movements for the selected page and pageSize sorted by 'reason' when sortedAsc is true and when it is false`() =
-    assertExternalMovements(sortColumn = "reason", expectedForAscending = AllMovements.externalMovement2, expectedForDescending = AllMovements.externalMovement1)
+    assertExternalMovements(sortColumn = "reason", expectedForAscending = movementPrisoner2, expectedForDescending = movementPrisoner1)
 
   @Test
   fun `should return a list of all results with no filters`() {
@@ -180,19 +192,19 @@ class ExternalMovementRepositoryTest {
   @Test
   fun `should return all the movements on or after the provided start date`() {
     val actual = externalMovementRepository.list(1, 10, "date", false, Collections.singletonMap(ExternalMovementFilter.START_DATE, LocalDate.parse("2023-04-30")))
-    Assertions.assertEquals(listOf(AllMovements.externalMovement5, AllMovements.externalMovement4, AllMovements.externalMovement3), actual)
+    Assertions.assertEquals(listOf(movementPrisoner5, movementPrisoner4, movementPrisoner3), actual)
   }
 
   @Test
   fun `should return all the movements on or before the provided end date`() {
     val actual = externalMovementRepository.list(1, 10, "date", false, Collections.singletonMap(ExternalMovementFilter.END_DATE, LocalDate.parse("2023-04-25")))
-    Assertions.assertEquals(listOf(AllMovements.externalMovement2, AllMovements.externalMovement1), actual)
+    Assertions.assertEquals(listOf(movementPrisoner2, movementPrisoner1), actual)
   }
 
   @Test
   fun `should return all the movements between the provided start and end dates`() {
     val actual = externalMovementRepository.list(1, 10, "date", false, mapOf(ExternalMovementFilter.START_DATE to LocalDate.parse("2023-04-25"), ExternalMovementFilter.END_DATE to LocalDate.parse("2023-05-20")))
-    Assertions.assertEquals(listOf(AllMovements.externalMovement5, AllMovements.externalMovement4, AllMovements.externalMovement3, AllMovements.externalMovement2), actual)
+    Assertions.assertEquals(listOf(movementPrisoner5, movementPrisoner4, movementPrisoner3, movementPrisoner2), actual)
   }
 
   @Test
@@ -226,8 +238,23 @@ class ExternalMovementRepositoryTest {
       "Transfer",
       "Transfer In from Other Establishment",
     )
+    val prisoner9846 = PrisonerEntity(9846, "W2505GF", "FirstName6", "LastName6", null)
+    val movementPrisonerNullValues = ExternalMovementPrisonerEntity(
+      6,
+      9846,
+      "FirstName6",
+      "LastName6",
+      LocalDateTime.of(2050, 6, 1, 0, 0, 0),
+      LocalDateTime.of(2050, 6, 1, 12, 0, 0),
+      null,
+      null,
+      null,
+      "Transfer",
+      "Transfer In from Other Establishment",
+    )
     try {
       externalMovementRepository.save(externalMovementNullValues)
+      prisonerRepository.save(prisoner9846)
       val actual = externalMovementRepository.list(
         1,
         1,
@@ -238,14 +265,15 @@ class ExternalMovementRepositoryTest {
           ExternalMovementFilter.END_DATE to LocalDate.of(2050, 6, 1),
         ),
       )
-      Assertions.assertEquals(listOf(externalMovementNullValues), actual)
+      Assertions.assertEquals(listOf(movementPrisonerNullValues), actual)
       Assertions.assertEquals(1, actual.size)
     } finally {
       externalMovementRepository.delete(externalMovementNullValues)
+      prisonerRepository.delete(prisoner9846)
     }
   }
 
-  private fun assertExternalMovements(sortColumn: String, expectedForAscending: ExternalMovementEntity, expectedForDescending: ExternalMovementEntity): List<DynamicTest> {
+  private fun assertExternalMovements(sortColumn: String, expectedForAscending: ExternalMovementPrisonerEntity, expectedForDescending: ExternalMovementPrisonerEntity): List<DynamicTest> {
     return listOf(
       true to listOf(expectedForAscending),
       false to listOf(expectedForDescending),
@@ -322,5 +350,35 @@ class ExternalMovementRepositoryTest {
       externalMovement4,
       externalMovement5,
     )
+  }
+  object AllPrisoners {
+    val prisoner8894 = PrisonerEntity(8894, "G2504UV", "FirstName1", "LastName1", null)
+    val prisoner5207 = PrisonerEntity(5207, "G2927UV", "FirstName2", "LastName2", null)
+    val prisoner4800 = PrisonerEntity(4800, "G3418VR", "FirstName3", "LastName3", null)
+    val prisoner7849 = PrisonerEntity(7849, "G3411VR", "FirstName4", "LastName4", 142595)
+    val prisoner6851 = PrisonerEntity(6851, "G3154UG", "FirstName5", "LastName5", null)
+
+    val allPrisoners = listOf(
+      prisoner8894,
+      prisoner5207,
+      prisoner4800,
+      prisoner7849,
+      prisoner6851,
+    )
+  }
+
+  object AllMovementPrisoners {
+    val allMovementPrisoners = allExternalMovements.mapIndexed { i, em ->
+      ExternalMovementPrisonerEntity(
+        em.id, em.prisoner,
+        "FirstName${i + 1}", "LastName${i + 1}", em.date, em.time,
+        em.origin, em.destination, em.direction, em.type, em.reason,
+      )
+    }
+    val movementPrisoner1 = allMovementPrisoners[0]
+    val movementPrisoner2 = allMovementPrisoners[1]
+    val movementPrisoner3 = allMovementPrisoners[2]
+    val movementPrisoner4 = allMovementPrisoners[3]
+    val movementPrisoner5 = allMovementPrisoners[4]
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/data/PrisonerEntity.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/data/PrisonerEntity.kt
@@ -1,0 +1,20 @@
+package uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "prisoner_prisoner", schema = "domain")
+class PrisonerEntity(
+  @Id
+  val id: Long,
+  val number: String,
+  @Column(name = "firstname")
+  val firstName: String,
+  @Column(name = "lastname")
+  val lastName: String,
+  @Column(name = "living_unit_reference")
+  val livingUnitReference: Long?,
+)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/data/PrisonerRepository.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/data/PrisonerRepository.kt
@@ -1,0 +1,5 @@
+package uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data
+
+import org.springframework.data.repository.CrudRepository
+
+interface PrisonerRepository : CrudRepository<PrisonerEntity, String>

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/integration/ExternalMovementsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/integration/ExternalMovementsIntegrationTest.kt
@@ -10,6 +10,13 @@ import org.springframework.test.web.reactive.server.expectBodyList
 import org.springframework.web.util.UriBuilder
 import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.ExternalMovementRepository
 import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.ExternalMovementRepositoryTest
+import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.ExternalMovementRepositoryTest.AllPrisoners
+import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.ExternalMovementRepositoryTest.AllPrisoners.prisoner4800
+import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.ExternalMovementRepositoryTest.AllPrisoners.prisoner5207
+import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.ExternalMovementRepositoryTest.AllPrisoners.prisoner6851
+import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.ExternalMovementRepositoryTest.AllPrisoners.prisoner7849
+import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.ExternalMovementRepositoryTest.AllPrisoners.prisoner8894
+import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.PrisonerRepository
 import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.model.ExternalMovementModel
 
 class ExternalMovementsIntegrationTest : IntegrationTestBase() {
@@ -17,15 +24,21 @@ class ExternalMovementsIntegrationTest : IntegrationTestBase() {
   @Autowired
   lateinit var externalMovementRepository: ExternalMovementRepository
 
+  @Autowired
+  lateinit var prisonerRepository: PrisonerRepository
+
   @BeforeEach
   fun setup() {
     ExternalMovementRepositoryTest.AllMovements.allExternalMovements.forEach {
       externalMovementRepository.save(it)
     }
+    AllPrisoners.allPrisoners.forEach {
+      prisonerRepository.save(it)
+    }
   }
 
   @Test
-  fun `External movements count returns stubbed value`() {
+  fun `External movements count returns the number of movements`() {
     webTestClient.get()
       .uri("/external-movements/count")
       .headers(setAuthorisation(roles = listOf(authorisedRole)))
@@ -59,7 +72,7 @@ class ExternalMovementsIntegrationTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `External movements returns stubbed value`() {
+  fun `External movements returns value from the repository`() {
     webTestClient.get()
       .uri { uriBuilder: UriBuilder ->
         uriBuilder
@@ -77,9 +90,9 @@ class ExternalMovementsIntegrationTest : IntegrationTestBase() {
       .expectBody()
       .json(
         """[
-        {"id": 5, "prisonNumber":"6851","date":"2023-05-20","time":"14:00:00","from":"Isle of Wight","to":"Northumberland","direction":"In","type":"Transfer","reason":"Transfer In from Other Establishment"},
-        {"id": 4, "prisonNumber":"7849","date":"2023-05-01","time":"15:19:00","from":"Cardiff","to":"Maidstone","direction":"Out","type":"Transfer","reason":"Transfer Out to Other Establishment"},
-        {"id": 3, "prisonNumber":"4800","date":"2023-04-30","time":"13:19:00","from":"Wakefield","to":"Dartmoor","direction":"In","type":"Transfer","reason":"Transfer In from Other Establishment"}
+        {"id": 5, "prisonNumber":"6851","firstName": "${prisoner6851.firstName}", "lastName": "${prisoner6851.lastName}","date":"2023-05-20","time":"14:00:00","from":"Isle of Wight","to":"Northumberland","direction":"In","type":"Transfer","reason":"Transfer In from Other Establishment"},
+        {"id": 4, "prisonNumber":"7849","firstName": "${prisoner7849.firstName}", "lastName": "${prisoner7849.lastName}","date":"2023-05-01","time":"15:19:00","from":"Cardiff","to":"Maidstone","direction":"Out","type":"Transfer","reason":"Transfer Out to Other Establishment"},
+        {"id": 3, "prisonNumber":"4800","firstName": "${prisoner4800.firstName}", "lastName": "${prisoner4800.lastName}","date":"2023-04-30","time":"13:19:00","from":"Wakefield","to":"Dartmoor","direction":"In","type":"Transfer","reason":"Transfer In from Other Establishment"}
       ]       
       """,
       )
@@ -101,11 +114,11 @@ class ExternalMovementsIntegrationTest : IntegrationTestBase() {
       .json(
         """
       [
-        {"id": 5, "prisonNumber":"6851","date":"2023-05-20","time":"14:00:00","from":"Isle of Wight","to":"Northumberland","direction":"In","type":"Transfer","reason":"Transfer In from Other Establishment"},
-        {"id": 4, "prisonNumber":"7849","date":"2023-05-01","time":"15:19:00","from":"Cardiff","to":"Maidstone","direction":"Out","type":"Transfer","reason":"Transfer Out to Other Establishment"},
-        {"id": 3, "prisonNumber":"4800","date":"2023-04-30","time":"13:19:00","from":"Wakefield","to":"Dartmoor","direction":"In","type":"Transfer","reason":"Transfer In from Other Establishment"},
-        {"id": 2, "prisonNumber":"5207","date": "2023-04-25","time":"12:19:00","from":"Elmley","to":"Pentonville","direction":"In","type":"Transfer","reason":"Transfer In from Other Establishment"},
-        {"id": 1, "prisonNumber":"8894","date": "2023-01-31","time":"03:01:00","from":"Ranby","to":"Kirkham","direction":"In","type":"Admission","reason":"Unconvicted Remand"}
+        {"id": 5, "prisonNumber":"6851", "firstName": "${prisoner6851.firstName}", "lastName": "${prisoner6851.lastName}", "date":"2023-05-20","time":"14:00:00","from":"Isle of Wight","to":"Northumberland","direction":"In","type":"Transfer","reason":"Transfer In from Other Establishment"},
+        {"id": 4, "prisonNumber":"7849", "firstName": "${prisoner7849.firstName}", "lastName": "${prisoner7849.lastName}", "date":"2023-05-01","time":"15:19:00","from":"Cardiff","to":"Maidstone","direction":"Out","type":"Transfer","reason":"Transfer Out to Other Establishment"},
+        {"id": 3, "prisonNumber":"4800", "firstName": "${prisoner4800.firstName}", "lastName": "${prisoner4800.lastName}", "date":"2023-04-30","time":"13:19:00","from":"Wakefield","to":"Dartmoor","direction":"In","type":"Transfer","reason":"Transfer In from Other Establishment"},
+        {"id": 2, "prisonNumber":"5207", "firstName": "${prisoner5207.firstName}", "lastName": "${prisoner5207.lastName}", "date": "2023-04-25","time":"12:19:00","from":"Elmley","to":"Pentonville","direction":"In","type":"Transfer","reason":"Transfer In from Other Establishment"},
+        {"id": 1, "prisonNumber":"8894", "firstName": "${prisoner8894.firstName}", "lastName": "${prisoner8894.lastName}", "date": "2023-01-31","time":"03:01:00","from":"Ranby","to":"Kirkham","direction":"In","type":"Admission","reason":"Unconvicted Remand"}
       ]
       """,
       )
@@ -187,7 +200,7 @@ class ExternalMovementsIntegrationTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `External movements returns stubbed value matching the filters provided`() {
+  fun `External movements returns value matching the filters provided`() {
     webTestClient.get()
       .uri { uriBuilder: UriBuilder ->
         uriBuilder
@@ -204,7 +217,7 @@ class ExternalMovementsIntegrationTest : IntegrationTestBase() {
       .expectBody()
       .json(
         """[
-         {"id": 4, "prisonNumber": "7849", "date": "2023-05-01", "time": "15:19:00", "from": "Cardiff", "to": "Maidstone", "direction": "Out", "type": "Transfer", "reason": "Transfer Out to Other Establishment"}
+         {"id": 4, "prisonNumber": "7849", "firstName": "${prisoner7849.firstName}", "lastName": "${prisoner7849.lastName}", "date": "2023-05-01", "time": "15:19:00", "from": "Cardiff", "to": "Maidstone", "direction": "Out", "type": "Transfer", "reason": "Transfer Out to Other Establishment"}
       ]       
       """,
       )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/service/ExternalMovementServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/service/ExternalMovementServiceTest.kt
@@ -12,8 +12,10 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.ExternalMovementEntity
+import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.ExternalMovementPrisonerEntity
 import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.ExternalMovementRepository
+import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.ExternalMovementRepositoryTest.AllPrisoners.prisoner5207
+import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.ExternalMovementRepositoryTest.AllPrisoners.prisoner8894
 import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.model.ExternalMovementFilter.DIRECTION
 import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.model.ExternalMovementModel
 import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.service.ExternalMovementServiceTest.AllEntities.allExternalMovementEntities
@@ -67,6 +69,8 @@ class ExternalMovementServiceTest {
     val externalMovement1 = ExternalMovementModel(
       1,
       "8894",
+      prisoner8894.firstName,
+      prisoner8894.lastName,
       LocalDate.of(2023, 1, 31),
       LocalTime.of(3, 1),
       "Ranby",
@@ -78,6 +82,8 @@ class ExternalMovementServiceTest {
     val externalMovement2 = ExternalMovementModel(
       2,
       "5207",
+      prisoner5207.firstName,
+      prisoner5207.lastName,
       LocalDate.of(2023, 4, 25),
       LocalTime.of(12, 19),
       "Elmley",
@@ -93,9 +99,11 @@ class ExternalMovementServiceTest {
   }
 
   object AllEntities {
-    val externalMovement1 = ExternalMovementEntity(
+    val externalMovement1 = ExternalMovementPrisonerEntity(
       1,
-      8894,
+      prisoner8894.id,
+      prisoner8894.firstName,
+      prisoner8894.lastName,
       LocalDateTime.of(2023, 1, 31, 0, 0, 0),
       LocalDateTime.of(2023, 1, 31, 3, 1, 0),
       "Ranby",
@@ -104,9 +112,11 @@ class ExternalMovementServiceTest {
       "Admission",
       "Unconvicted Remand",
     )
-    val externalMovement2 = ExternalMovementEntity(
+    val externalMovement2 = ExternalMovementPrisonerEntity(
       2,
-      5207,
+      prisoner5207.id,
+      prisoner5207.firstName,
+      prisoner5207.lastName,
       LocalDateTime.of(2023, 4, 25, 0, 0, 0),
       LocalDateTime.of(2023, 4, 25, 12, 19, 0),
       "Elmley",


### PR DESCRIPTION
This PR adds prisoner first name and last name to the API response.
These two fields originate from the prisoner_prisoner table which is being joined to the movements_movements table.