### PR TITLE
[DPR2-71] Refactor product data definition structure and add additional fields

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/controller/model/FieldDefinition.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/controller/model/FieldDefinition.kt
@@ -8,4 +8,5 @@ data class FieldDefinition(
   val filter: FilterDefinition? = null,
   val sortable: Boolean = true,
   val defaultSortColumn: Boolean = false,
+  val type: FieldType,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/controller/model/FieldDefinition.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/controller/model/FieldDefinition.kt
@@ -3,7 +3,6 @@ package uk.gov.justice.digital.hmpps.digitalprisonreportingmi.controller.model
 data class FieldDefinition(
   val name: String,
   val displayName: String,
-  val dateFormat: String? = null,
   val wordWrap: WordWrap? = null,
   val filter: FilterDefinition? = null,
   val sortable: Boolean = true,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/controller/model/FieldType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/controller/model/FieldType.kt
@@ -1,0 +1,8 @@
+package uk.gov.justice.digital.hmpps.digitalprisonreportingmi.controller.model
+
+enum class FieldType {
+  String,
+  Date,
+  Long,
+  ;
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/controller/model/FilterDefinition.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/controller/model/FilterDefinition.kt
@@ -3,4 +3,5 @@ package uk.gov.justice.digital.hmpps.digitalprisonreportingmi.controller.model
 data class FilterDefinition(
   val type: FilterType,
   val staticOptions: List<FilterOption>? = null,
+  val defaultValue: String?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/controller/model/ReportDefinition.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/controller/model/ReportDefinition.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.digitalprisonreportingmi.controller.model
 
 data class ReportDefinition(
+  val id: String,
   val name: String,
   val description: String? = null,
   val variants: List<VariantDefinition>,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/controller/model/Specification.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/controller/model/Specification.kt
@@ -1,0 +1,6 @@
+package uk.gov.justice.digital.hmpps.digitalprisonreportingmi.controller.model
+
+data class Specification(
+  val template: String,
+  val fields: List<FieldDefinition>,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/controller/model/VariantDefinition.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/controller/model/VariantDefinition.kt
@@ -5,6 +5,5 @@ data class VariantDefinition(
   val name: String,
   val resourceName: String,
   val description: String?,
-  val specification: String?,
-  val fields: List<FieldDefinition>,
+  val specification: Specification?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/controller/model/VariantDefinition.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/controller/model/VariantDefinition.kt
@@ -4,6 +4,6 @@ data class VariantDefinition(
   val id: String,
   val name: String,
   val resourceName: String,
-  val description: String?,
-  val specification: Specification?,
+  val description: String? = null,
+  val specification: Specification? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/data/StubbedProductDefinitionRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/data/StubbedProductDefinitionRepository.kt
@@ -175,7 +175,7 @@ class StubbedProductDefinitionRepository : ProductDefinitionRepository {
                   defaultSortColumn = true,
                   filter = FilterDefinition(
                     type = FilterType.DateRange,
-                    defaultValue = "today(-7,Days) - today()",
+                    defaultValue = "today(-1,weeks) - today()",
                   ),
                 ),
                 ReportField(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/data/StubbedProductDefinitionRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/data/StubbedProductDefinitionRepository.kt
@@ -175,8 +175,8 @@ class StubbedProductDefinitionRepository : ProductDefinitionRepository {
                   defaultSortColumn = true,
                   filter = FilterDefinition(
                     type = FilterType.DateRange,
+                    defaultValue = "today(-7,Days) - today()",
                   ),
-                  defaultFilter = "",
                 ),
                 ReportField(
                   schemaField = "\$ref:origin",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/data/StubbedProductDefinitionRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/data/StubbedProductDefinitionRepository.kt
@@ -7,11 +7,14 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model.FilterDe
 import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model.FilterOption
 import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model.FilterType
 import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model.MetaData
-import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model.Parameter
 import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model.ParameterType
 import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model.ProductDefinition
 import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model.RenderMethod
 import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model.Report
+import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model.ReportField
+import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model.Schema
+import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model.SchemaField
+import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model.Specification
 import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model.WordWrap
 import java.time.LocalDate
 
@@ -19,66 +22,37 @@ import java.time.LocalDate
 class StubbedProductDefinitionRepository : ProductDefinitionRepository {
 
   override fun getProductDefinitions(): List<ProductDefinition> {
-    val parameters = listOf(
-      Parameter(
+    val fields = listOf(
+      SchemaField(
         name = "prisonNumber",
-        displayName = "Prison Number",
         type = ParameterType.String,
       ),
-      Parameter(
+      SchemaField(
         name = "name",
-        displayName = "Name",
-        wordWrap = WordWrap.None,
         type = ParameterType.String,
       ),
-      Parameter(
+      SchemaField(
         name = "date",
-        displayName = "Date",
-        dateFormat = "dd/MM/yy",
-        defaultSortColumn = true,
-        filter = FilterDefinition(
-          type = FilterType.DateRange,
-        ),
         type = ParameterType.Date,
       ),
-      Parameter(
-        name = "date",
-        displayName = "Time",
-        dateFormat = "HH:mm",
-        type = ParameterType.Date,
-      ),
-      Parameter(
+      SchemaField(
         name = "origin",
-        displayName = "From",
-        wordWrap = WordWrap.None,
         type = ParameterType.String,
       ),
-      Parameter(
+      SchemaField(
         name = "destination",
-        displayName = "To",
-        wordWrap = WordWrap.None,
         type = ParameterType.String,
       ),
-      Parameter(
+      SchemaField(
         name = "direction",
-        displayName = "Direction",
-        filter = FilterDefinition(
-          type = FilterType.Radio,
-          staticOptions = listOf(
-            FilterOption("in", "In"),
-            FilterOption("out", "Out"),
-          ),
-        ),
         type = ParameterType.String,
       ),
-      Parameter(
+      SchemaField(
         name = "type",
-        displayName = "Type",
         type = ParameterType.String,
       ),
-      Parameter(
+      SchemaField(
         name = "reason",
-        displayName = "Reason",
         type = ParameterType.String,
       ),
     )
@@ -104,25 +78,9 @@ class StubbedProductDefinitionRepository : ProductDefinitionRepository {
               "FROM datamart.domain.movements_movements as movements\n" +
               "JOIN datamart.domain.prisoner_prisoner as prisoners\n" +
               "ON movements.prisoner = prisoners.id",
-            parameters = parameters,
-          ),
-          DataSet(
-            id = "last-week",
-            name = "Last week",
-            query = "SELECT " +
-              "prisoners.number AS prisonNumber," +
-              "CONCAT(prisoners.lastname, ', ', substring(prisoners.firstname, 1, 1)) AS name," +
-              "movements.date," +
-              "movements.direction," +
-              "movements.type," +
-              "movements.origin," +
-              "movements.destination," +
-              "movements.reason\n" +
-              "FROM datamart.domain.movements_movements as movements\n" +
-              "JOIN datamart.domain.prisoner_prisoner as prisoners\n" +
-              "ON movements.prisoner = prisoners.id\n" +
-              "WHERE DATE_PART('day', CURRENT_DATE() - movements.date) BETWEEN 0 AND 7",
-            parameters = parameters,
+            schema = Schema(
+              field = fields,
+            ),
           ),
         ),
         dataSource = listOf(
@@ -138,7 +96,57 @@ class StubbedProductDefinitionRepository : ProductDefinitionRepository {
             name = "All movements",
             dataset = "\$ref:list",
             policy = emptyList(),
-            specification = "list",
+            specification = Specification(
+              template = "list",
+              field = listOf(
+                ReportField(
+                  schemaField = "\$ref:prisonNumber",
+                  displayName = "Prison Number",
+                ),
+                ReportField(
+                  schemaField = "\$ref:name",
+                  displayName = "Name",
+                  wordWrap = WordWrap.None,
+                ),
+                ReportField(
+                  schemaField = "\$ref:date",
+                  displayName = "Date",
+                  defaultSortColumn = true,
+                  filter = FilterDefinition(
+                    type = FilterType.DateRange,
+                  ),
+                ),
+                ReportField(
+                  schemaField = "\$ref:origin",
+                  displayName = "From",
+                  wordWrap = WordWrap.None,
+                ),
+                ReportField(
+                  schemaField = "\$ref:destination",
+                  displayName = "To",
+                  wordWrap = WordWrap.None,
+                ),
+                ReportField(
+                  schemaField = "\$ref:direction",
+                  displayName = "Direction",
+                  filter = FilterDefinition(
+                    type = FilterType.Radio,
+                    staticOptions = listOf(
+                      FilterOption("in", "In"),
+                      FilterOption("out", "Out"),
+                    ),
+                  ),
+                ),
+                ReportField(
+                  schemaField = "\$ref:type",
+                  displayName = "Type",
+                ),
+                ReportField(
+                  schemaField = "\$ref:reason",
+                  displayName = "Reason",
+                ),
+              ),
+            ),
             render = RenderMethod.HTML,
             created = LocalDate.now(),
             version = "1.2.3",
@@ -147,9 +155,60 @@ class StubbedProductDefinitionRepository : ProductDefinitionRepository {
             id = "1.b",
             name = "Last week",
             description = "All movements in the past week",
-            dataset = "\$ref:last-week",
+            dataset = "\$ref:list",
             policy = emptyList(),
-            specification = "list",
+            specification = Specification(
+              template = "list",
+              field = listOf(
+                ReportField(
+                  schemaField = "\$ref:prisonNumber",
+                  displayName = "Prison Number",
+                ),
+                ReportField(
+                  schemaField = "\$ref:name",
+                  displayName = "Name",
+                  wordWrap = WordWrap.None,
+                ),
+                ReportField(
+                  schemaField = "\$ref:date",
+                  displayName = "Date",
+                  defaultSortColumn = true,
+                  filter = FilterDefinition(
+                    type = FilterType.DateRange,
+                  ),
+                  defaultFilter = "",
+                ),
+                ReportField(
+                  schemaField = "\$ref:origin",
+                  displayName = "From",
+                  wordWrap = WordWrap.None,
+                ),
+                ReportField(
+                  schemaField = "\$ref:destination",
+                  displayName = "To",
+                  wordWrap = WordWrap.None,
+                ),
+                ReportField(
+                  schemaField = "\$ref:direction",
+                  displayName = "Direction",
+                  filter = FilterDefinition(
+                    type = FilterType.Radio,
+                    staticOptions = listOf(
+                      FilterOption("in", "In"),
+                      FilterOption("out", "Out"),
+                    ),
+                  ),
+                ),
+                ReportField(
+                  schemaField = "\$ref:type",
+                  displayName = "Type",
+                ),
+                ReportField(
+                  schemaField = "\$ref:reason",
+                  displayName = "Reason",
+                ),
+              ),
+            ),
             render = RenderMethod.HTML,
             created = LocalDate.now(),
             version = "1.2.3",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/data/StubbedProductDefinitionRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/data/StubbedProductDefinitionRepository.kt
@@ -92,8 +92,9 @@ class StubbedProductDefinitionRepository : ProductDefinitionRepository {
         ),
         report = listOf(
           Report(
-            id = "1.a",
-            name = "All movements",
+            id = "last-month",
+            name = "Last month",
+            description = "All movements in the past month",
             dataset = "\$ref:list",
             policy = emptyList(),
             specification = Specification(
@@ -114,6 +115,7 @@ class StubbedProductDefinitionRepository : ProductDefinitionRepository {
                   defaultSortColumn = true,
                   filter = FilterDefinition(
                     type = FilterType.DateRange,
+                    defaultValue = "today(-1,months) - today()",
                   ),
                 ),
                 ReportField(
@@ -152,7 +154,7 @@ class StubbedProductDefinitionRepository : ProductDefinitionRepository {
             version = "1.2.3",
           ),
           Report(
-            id = "1.b",
+            id = "last-week",
             name = "Last week",
             description = "All movements in the past week",
             dataset = "\$ref:list",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/data/model/FilterDefinition.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/data/model/FilterDefinition.kt
@@ -3,4 +3,5 @@ package uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model
 data class FilterDefinition(
   val type: FilterType,
   val staticOptions: List<FilterOption>? = null,
+  val defaultValue: String? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/data/model/Report.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/data/model/Report.kt
@@ -12,6 +12,6 @@ data class Report(
   val policy: List<String> = emptyList(),
   val render: RenderMethod,
   val schedule: String? = null,
-  val specification: String? = null,
+  val specification: Specification? = null,
   val destination: List<Map<String, String>> = emptyList(),
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/data/model/ReportField.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/data/model/ReportField.kt
@@ -7,5 +7,4 @@ data class ReportField(
   val filter: FilterDefinition? = null,
   val sortable: Boolean = true,
   val defaultSortColumn: Boolean = false,
-  val defaultFilter: String? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/data/model/ReportField.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/data/model/ReportField.kt
@@ -1,12 +1,11 @@
 package uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model
 
-data class Parameter(
-  val name: String,
+data class ReportField(
+  val schemaField: String,
   val displayName: String,
-  val type: ParameterType,
-  val dateFormat: String? = null,
   val wordWrap: WordWrap? = null,
   val filter: FilterDefinition? = null,
   val sortable: Boolean = true,
   val defaultSortColumn: Boolean = false,
+  val defaultFilter: String? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/data/model/Schema.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/data/model/Schema.kt
@@ -1,0 +1,5 @@
+package uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model
+
+data class Schema(
+  val field: List<SchemaField>,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/data/model/SchemaField.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/data/model/SchemaField.kt
@@ -1,8 +1,6 @@
 package uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model
 
-data class DataSet(
-  val id: String,
+data class SchemaField(
   val name: String,
-  val query: String,
-  val schema: Schema,
+  val type: ParameterType,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/data/model/Specification.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/data/model/Specification.kt
@@ -1,0 +1,6 @@
+package uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model
+
+data class Specification(
+  val template: String,
+  val field: List<ReportField>,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/service/ReportDefinitionMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/service/ReportDefinitionMapper.kt
@@ -1,0 +1,130 @@
+package uk.gov.justice.digital.hmpps.digitalprisonreportingmi.service
+
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.controller.model.FieldDefinition
+import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.controller.model.FieldType
+import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.controller.model.FilterDefinition
+import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.controller.model.FilterOption
+import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.controller.model.FilterType
+import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.controller.model.RenderMethod
+import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.controller.model.ReportDefinition
+import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.controller.model.Specification
+import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.controller.model.VariantDefinition
+import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.controller.model.WordWrap
+import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model.DataSet
+import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model.ProductDefinition
+import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model.Report
+import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model.ReportField
+import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model.SchemaField
+import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.service.ReportDefinitionMapper.DateDifferenceMagnitude.Days
+import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.service.ReportDefinitionMapper.DateDifferenceMagnitude.Months
+import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.service.ReportDefinitionMapper.DateDifferenceMagnitude.Weeks
+import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.service.ReportDefinitionMapper.DateDifferenceMagnitude.Years
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter.ISO_LOCAL_DATE
+
+@Component
+class ReportDefinitionMapper {
+
+  val todayRegex: Regex = Regex("today\\(\\)")
+  val dateRegex: Regex = Regex("today\\((-?\\d+), ?(.[a-z]+)\\)")
+
+  fun map(definition: ProductDefinition, renderMethod: RenderMethod?): ReportDefinition = ReportDefinition(
+    id = definition.id,
+    name = definition.name,
+    description = definition.description,
+    variants = definition.report
+      .filter { renderMethod == null || it.render.toString() == renderMethod.toString() }
+      .map { map(it, definition.dataSet) },
+  )
+
+  private fun map(definition: Report, dataSets: List<DataSet>): VariantDefinition {
+    val dataSetRef = definition.dataset.removePrefix("\$ref:")
+    val dataSet = dataSets.find { it.id == dataSetRef }
+      ?: throw IllegalArgumentException("Could not find matching DataSet '$dataSetRef'")
+
+    return VariantDefinition(
+      id = definition.id,
+      name = definition.name,
+      description = definition.description,
+      specification = map(definition.specification, dataSet.schema.field),
+      resourceName = dataSet.id,
+    )
+  }
+
+  private fun map(
+    specification: uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model.Specification?,
+    schemaFields: List<SchemaField>,
+
+  ): Specification? {
+    if (specification == null) {
+      return null
+    }
+
+    return Specification(
+      template = specification.template,
+      fields = specification.field.map { map(it, schemaFields) },
+    )
+  }
+
+  private fun map(field: ReportField, schemaFields: List<SchemaField>): FieldDefinition {
+    val schemaFieldRef = field.schemaField.removePrefix("\$ref:")
+    val schemaField = schemaFields.find { it.name == schemaFieldRef }
+      ?: throw IllegalArgumentException("Could not find matching Schema Field '$schemaFieldRef'")
+
+    return FieldDefinition(
+      name = schemaField.name,
+      displayName = field.displayName,
+      wordWrap = field.wordWrap?.toString()?.let(WordWrap::valueOf),
+      filter = field.filter?.let(this::map),
+      sortable = field.sortable,
+      defaultSortColumn = field.defaultSortColumn,
+      type = schemaField.type.toString().let(FieldType::valueOf),
+    )
+  }
+
+  private fun map(definition: uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model.FilterDefinition): FilterDefinition = FilterDefinition(
+    type = FilterType.valueOf(definition.type.toString()),
+    staticOptions = definition.staticOptions?.map(this::map),
+    defaultValue = replaceTokens(definition.defaultValue),
+  )
+
+  private fun replaceTokens(defaultValue: String?): String? {
+    if (defaultValue == null) {
+      return null
+    }
+
+    val today = LocalDate.now().format(ISO_LOCAL_DATE)
+    var result = defaultValue.replace(todayRegex, today)
+
+    if (result.matches(dateRegex)) {
+      dateRegex.findAll(result)
+        .forEach {
+          val offset = it.groupValues[0].toLong()
+
+          val resultDate = when (DateDifferenceMagnitude.valueOf(it.groupValues[1])) {
+            Days -> LocalDate.now().plusDays(offset)
+            Weeks -> LocalDate.now().plusWeeks(offset)
+            Months -> LocalDate.now().plusMonths(offset)
+            Years -> LocalDate.now().plusYears(offset)
+          }
+
+          result = result.replace(it.value, resultDate.format(ISO_LOCAL_DATE))
+        }
+    }
+
+    return result
+  }
+
+  private fun map(definition: uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model.FilterOption): FilterOption = FilterOption(
+    name = definition.name,
+    displayName = definition.displayName,
+  )
+
+  enum class DateDifferenceMagnitude {
+    Days,
+    Weeks,
+    Months,
+    Years,
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/service/ReportDefinitionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/service/ReportDefinitionService.kt
@@ -8,13 +8,15 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.controller.model.Fi
 import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.controller.model.FilterType
 import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.controller.model.RenderMethod
 import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.controller.model.ReportDefinition
+import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.controller.model.Specification
 import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.controller.model.VariantDefinition
 import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.controller.model.WordWrap
 import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.ProductDefinitionRepository
 import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model.DataSet
-import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model.Parameter
 import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model.ProductDefinition
 import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model.Report
+import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model.ReportField
+import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model.SchemaField
 
 @Service
 class ReportDefinitionService(val productDefinitionRepository: ProductDefinitionRepository) {
@@ -43,22 +45,41 @@ class ReportDefinitionService(val productDefinitionRepository: ProductDefinition
       id = definition.id,
       name = definition.name,
       description = definition.description,
-      specification = definition.specification,
+      specification = map(definition.specification, dataSet.schema.field),
       resourceName = dataSet.id,
-      fields = dataSet.parameters.map(this::map),
     )
   }
 
-  private fun map(definition: Parameter): FieldDefinition = FieldDefinition(
-    name = definition.name,
-    displayName = definition.displayName,
-    dateFormat = definition.dateFormat,
-    wordWrap = definition.wordWrap?.toString()?.let(WordWrap::valueOf),
-    filter = definition.filter?.let(this::map),
-    sortable = definition.sortable,
-    defaultSortColumn = definition.defaultSortColumn,
-    type = definition.type.toString().let(FieldType::valueOf),
-  )
+  private fun map(
+    specification: uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model.Specification?,
+    schemaFields: List<SchemaField>,
+
+  ): Specification? {
+    if (specification == null) {
+      return null
+    }
+
+    return Specification(
+      template = specification.template,
+      fields = specification.field.map { map(it, schemaFields) },
+    )
+  }
+
+  private fun map(field: ReportField, schemaFields: List<SchemaField>): FieldDefinition {
+    val schemaFieldRef = field.schemaField.removePrefix("\$ref:")
+    val schemaField = schemaFields.find { it.name == schemaFieldRef }
+      ?: throw IllegalArgumentException("Could not find matching Schema Field '$schemaFieldRef'")
+
+    return FieldDefinition(
+      name = schemaField.name,
+      displayName = field.displayName,
+      wordWrap = field.wordWrap?.toString()?.let(WordWrap::valueOf),
+      filter = field.filter?.let(this::map),
+      sortable = field.sortable,
+      defaultSortColumn = field.defaultSortColumn,
+      type = schemaField.type.toString().let(FieldType::valueOf),
+    )
+  }
 
   private fun map(definition: uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model.FilterDefinition): FilterDefinition = FilterDefinition(
     type = FilterType.valueOf(definition.type.toString()),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/service/ReportDefinitionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/service/ReportDefinitionService.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.digitalprisonreportingmi.service
 
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.controller.model.FieldDefinition
+import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.controller.model.FieldType
 import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.controller.model.FilterDefinition
 import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.controller.model.FilterOption
 import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.controller.model.FilterType
@@ -25,6 +26,7 @@ class ReportDefinitionService(val productDefinitionRepository: ProductDefinition
   }
 
   private fun map(definition: ProductDefinition, renderMethod: RenderMethod?): ReportDefinition = ReportDefinition(
+    id = definition.id,
     name = definition.name,
     description = definition.description,
     variants = definition.report
@@ -55,6 +57,7 @@ class ReportDefinitionService(val productDefinitionRepository: ProductDefinition
     filter = definition.filter?.let(this::map),
     sortable = definition.sortable,
     defaultSortColumn = definition.defaultSortColumn,
+    type = definition.type.toString().let(FieldType::valueOf),
   )
 
   private fun map(definition: uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model.FilterDefinition): FilterDefinition = FilterDefinition(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/service/ReportDefinitionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/service/ReportDefinitionService.kt
@@ -1,137 +1,19 @@
 package uk.gov.justice.digital.hmpps.digitalprisonreportingmi.service
 
 import org.springframework.stereotype.Service
-import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.controller.model.FieldDefinition
-import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.controller.model.FieldType
-import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.controller.model.FilterDefinition
-import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.controller.model.FilterOption
-import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.controller.model.FilterType
 import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.controller.model.RenderMethod
 import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.controller.model.ReportDefinition
-import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.controller.model.Specification
-import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.controller.model.VariantDefinition
-import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.controller.model.WordWrap
 import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.ProductDefinitionRepository
-import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model.DataSet
-import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model.ProductDefinition
-import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model.Report
-import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model.ReportField
-import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model.SchemaField
-import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.service.DateDifferenceMagnitude.Days
-import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.service.DateDifferenceMagnitude.Months
-import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.service.DateDifferenceMagnitude.Weeks
-import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.service.DateDifferenceMagnitude.Years
-import java.time.LocalDate
-import java.time.format.DateTimeFormatter.ISO_LOCAL_DATE
-
-val todayRegex: Regex = Regex("today\\(\\)")
-val dateRegex: Regex = Regex("today\\((-?\\d+), ?(.[a-z]+)\\)")
 
 @Service
-class ReportDefinitionService(val productDefinitionRepository: ProductDefinitionRepository) {
+class ReportDefinitionService(
+  val productDefinitionRepository: ProductDefinitionRepository,
+  val mapper: ReportDefinitionMapper,
+) {
 
   fun getListForUser(renderMethod: RenderMethod?): List<ReportDefinition> {
     return productDefinitionRepository.getProductDefinitions()
-      .map { map(it, renderMethod) }
+      .map { mapper.map(it, renderMethod) }
       .filter { it.variants.isNotEmpty() }
   }
-
-  private fun map(definition: ProductDefinition, renderMethod: RenderMethod?): ReportDefinition = ReportDefinition(
-    id = definition.id,
-    name = definition.name,
-    description = definition.description,
-    variants = definition.report
-      .filter { renderMethod == null || it.render.toString() == renderMethod.toString() }
-      .map { map(it, definition.dataSet) },
-  )
-
-  private fun map(definition: Report, dataSets: List<DataSet>): VariantDefinition {
-    val dataSetRef = definition.dataset.removePrefix("\$ref:")
-    val dataSet = dataSets.find { it.id == dataSetRef }
-      ?: throw IllegalArgumentException("Could not find matching DataSet '$dataSetRef'")
-
-    return VariantDefinition(
-      id = definition.id,
-      name = definition.name,
-      description = definition.description,
-      specification = map(definition.specification, dataSet.schema.field),
-      resourceName = dataSet.id,
-    )
-  }
-
-  private fun map(
-    specification: uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model.Specification?,
-    schemaFields: List<SchemaField>,
-
-  ): Specification? {
-    if (specification == null) {
-      return null
-    }
-
-    return Specification(
-      template = specification.template,
-      fields = specification.field.map { map(it, schemaFields) },
-    )
-  }
-
-  private fun map(field: ReportField, schemaFields: List<SchemaField>): FieldDefinition {
-    val schemaFieldRef = field.schemaField.removePrefix("\$ref:")
-    val schemaField = schemaFields.find { it.name == schemaFieldRef }
-      ?: throw IllegalArgumentException("Could not find matching Schema Field '$schemaFieldRef'")
-
-    return FieldDefinition(
-      name = schemaField.name,
-      displayName = field.displayName,
-      wordWrap = field.wordWrap?.toString()?.let(WordWrap::valueOf),
-      filter = field.filter?.let(this::map),
-      sortable = field.sortable,
-      defaultSortColumn = field.defaultSortColumn,
-      type = schemaField.type.toString().let(FieldType::valueOf),
-    )
-  }
-
-  private fun map(definition: uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model.FilterDefinition): FilterDefinition = FilterDefinition(
-    type = FilterType.valueOf(definition.type.toString()),
-    staticOptions = definition.staticOptions?.map(this::map),
-    defaultValue = replaceTokens(definition.defaultValue),
-  )
-
-  private fun replaceTokens(defaultValue: String?): String? {
-    if (defaultValue == null) {
-      return null
-    }
-
-    val today = LocalDate.now().format(ISO_LOCAL_DATE)
-    var result = defaultValue.replace(todayRegex, today)
-
-    if (result.matches(dateRegex)) {
-      dateRegex.findAll(result)
-        .forEach {
-          val offset = it.groupValues[0].toLong()
-
-          val resultDate = when (DateDifferenceMagnitude.valueOf(it.groupValues[1])) {
-            Days -> LocalDate.now().plusDays(offset)
-            Weeks -> LocalDate.now().plusWeeks(offset)
-            Months -> LocalDate.now().plusMonths(offset)
-            Years -> LocalDate.now().plusYears(offset)
-          }
-
-          result = result.replace(it.value, resultDate.format(ISO_LOCAL_DATE))
-        }
-    }
-
-    return result
-  }
-
-  private fun map(definition: uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model.FilterOption): FilterOption = FilterOption(
-    name = definition.name,
-    displayName = definition.displayName,
-  )
-}
-
-enum class DateDifferenceMagnitude {
-  Days,
-  Weeks,
-  Months,
-  Years,
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/integration/ReportDefinitionIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/integration/ReportDefinitionIntegrationTest.kt
@@ -31,17 +31,17 @@ class ReportDefinitionIntegrationTest : IntegrationTestBase() {
     assertThat(definition.variants[0]).isNotNull
     assertThat(definition.variants[1]).isNotNull
 
-    val allVariant = definition.variants[0]
+    val lastMonthVariant = definition.variants[0]
 
-    assertThat(allVariant.id).isEqualTo("1.a")
-    assertThat(allVariant.resourceName).isEqualTo("list")
-    assertThat(allVariant.description).isNull()
-    assertThat(allVariant.name).isEqualTo("All movements")
-    assertThat(allVariant.specification).isNotNull
-    assertThat(allVariant.specification?.fields).hasSize(8)
+    assertThat(lastMonthVariant.id).isEqualTo("last-month")
+    assertThat(lastMonthVariant.resourceName).isEqualTo("list")
+    assertThat(lastMonthVariant.name).isEqualTo("Last month")
+    assertThat(lastMonthVariant.description).isEqualTo("All movements in the past month")
+    assertThat(lastMonthVariant.specification).isNotNull
+    assertThat(lastMonthVariant.specification?.fields).hasSize(8)
 
     val lastWeekVariant = definition.variants[1]
-    assertThat(lastWeekVariant.id).isEqualTo("1.b")
+    assertThat(lastWeekVariant.id).isEqualTo("last-week")
     assertThat(lastWeekVariant.resourceName).isEqualTo("list")
     assertThat(lastWeekVariant.description).isEqualTo("All movements in the past week")
     assertThat(lastWeekVariant.name).isEqualTo("Last week")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/integration/ReportDefinitionIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/integration/ReportDefinitionIntegrationTest.kt
@@ -37,14 +37,16 @@ class ReportDefinitionIntegrationTest : IntegrationTestBase() {
     assertThat(allVariant.resourceName).isEqualTo("list")
     assertThat(allVariant.description).isNull()
     assertThat(allVariant.name).isEqualTo("All movements")
-    assertThat(allVariant.fields).hasSize(9)
+    assertThat(allVariant.specification).isNotNull
+    assertThat(allVariant.specification?.fields).hasSize(8)
 
     val lastWeekVariant = definition.variants[1]
     assertThat(lastWeekVariant.id).isEqualTo("1.b")
-    assertThat(lastWeekVariant.resourceName).isEqualTo("last-week")
+    assertThat(lastWeekVariant.resourceName).isEqualTo("list")
     assertThat(lastWeekVariant.description).isEqualTo("All movements in the past week")
     assertThat(lastWeekVariant.name).isEqualTo("Last week")
-    assertThat(lastWeekVariant.fields).hasSize(9)
+    assertThat(lastWeekVariant.specification).isNotNull
+    assertThat(lastWeekVariant.specification?.fields).hasSize(8)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/service/ReportDefinitionMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/service/ReportDefinitionMapperTest.kt
@@ -117,7 +117,6 @@ class ReportDefinitionMapperTest {
     assertThat(variant.id).isEqualTo(fullProductDefinition.report.first().id)
     assertThat(variant.name).isEqualTo(fullProductDefinition.report.first().name)
     assertThat(variant.resourceName).isEqualTo(fullProductDefinition.dataSet.first().id)
-    assertThat(variant.resourceName).isEqualTo(fullProductDefinition.dataSet.first().id)
     assertThat(variant.description).isEqualTo(fullProductDefinition.report.first().description)
     assertThat(variant.specification).isNotNull
     assertThat(variant.specification?.template).isEqualTo(fullProductDefinition.report.first().specification?.template)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/service/ReportDefinitionMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/service/ReportDefinitionMapperTest.kt
@@ -1,0 +1,241 @@
+package uk.gov.justice.digital.hmpps.digitalprisonreportingmi.service
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.controller.model.RenderMethod.HTML
+import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model.DataSet
+import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model.DataSource
+import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model.FilterDefinition
+import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model.FilterOption
+import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model.FilterType
+import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model.MetaData
+import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model.ParameterType
+import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model.ProductDefinition
+import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model.RenderMethod
+import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model.Report
+import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model.ReportField
+import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model.Schema
+import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model.SchemaField
+import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model.Specification
+import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model.WordWrap
+import java.time.LocalDate
+import java.util.Collections.singletonMap
+
+class ReportDefinitionMapperTest {
+
+  private val fullProductDefinition: ProductDefinition = ProductDefinition(
+    id = "1",
+    name = "2",
+    description = "3",
+    metaData = MetaData(
+      author = "4",
+      version = "5",
+      owner = "6",
+      purpose = "7",
+      profile = "8",
+      dqri = "9",
+    ),
+    dataSet = listOf(
+      DataSet(
+        id = "10",
+        name = "11",
+        query = "12",
+        schema = Schema(
+          field = listOf(
+            SchemaField(
+              name = "13",
+              type = ParameterType.Long,
+            ),
+          ),
+        ),
+      ),
+    ),
+    dataSource = listOf(
+      DataSource(
+        id = "18",
+        name = "19",
+        connection = "20",
+      ),
+    ),
+    report = listOf(
+      Report(
+        id = "21",
+        name = "22",
+        description = "23",
+        created = LocalDate.MAX,
+        version = "24",
+        dataset = "\$ref:10",
+        policy = listOf("25"),
+        render = RenderMethod.PDF,
+        schedule = "26",
+        specification = Specification(
+          template = "27",
+          field = listOf(
+            ReportField(
+              schemaField = "\$ref:13",
+              displayName = "14",
+              wordWrap = WordWrap.None,
+              filter = FilterDefinition(
+                type = FilterType.Radio,
+                staticOptions = listOf(
+                  FilterOption(
+                    name = "16",
+                    displayName = "17",
+                  ),
+                ),
+              ),
+              sortable = true,
+              defaultSortColumn = true,
+            ),
+          ),
+        ),
+        destination = listOf(singletonMap("28", "29")),
+      ),
+    ),
+  )
+
+  @Test
+  fun `Getting report list for user maps full data correctly`() {
+    val mapper = ReportDefinitionMapper()
+
+    val result = mapper.map(fullProductDefinition, null)
+
+    assertThat(result).isNotNull
+    assertThat(result.id).isEqualTo(fullProductDefinition.id)
+    assertThat(result.name).isEqualTo(fullProductDefinition.name)
+    assertThat(result.description).isEqualTo(fullProductDefinition.description)
+    assertThat(result.variants).isNotEmpty
+    assertThat(result.variants).hasSize(1)
+
+    val variant = result.variants.first()
+
+    assertThat(variant.id).isEqualTo(fullProductDefinition.report.first().id)
+    assertThat(variant.name).isEqualTo(fullProductDefinition.report.first().name)
+    assertThat(variant.resourceName).isEqualTo(fullProductDefinition.dataSet.first().id)
+    assertThat(variant.resourceName).isEqualTo(fullProductDefinition.dataSet.first().id)
+    assertThat(variant.description).isEqualTo(fullProductDefinition.report.first().description)
+    assertThat(variant.specification).isNotNull
+    assertThat(variant.specification?.template).isEqualTo(fullProductDefinition.report.first().specification?.template)
+    assertThat(variant.specification?.fields).isNotEmpty
+    assertThat(variant.specification?.fields).hasSize(1)
+
+    val field = variant.specification!!.fields.first()
+    val sourceSchemaField = fullProductDefinition.dataSet.first().schema.field.first()
+    val sourceReportField = fullProductDefinition.report.first().specification!!.field.first()
+
+    assertThat(field.name).isEqualTo(sourceSchemaField.name)
+    assertThat(field.displayName).isEqualTo(sourceReportField.displayName)
+    assertThat(field.wordWrap.toString()).isEqualTo(sourceReportField.wordWrap.toString())
+    assertThat(field.sortable).isEqualTo(sourceReportField.sortable)
+    assertThat(field.defaultSortColumn).isEqualTo(sourceReportField.defaultSortColumn)
+    assertThat(field.filter).isNotNull
+    assertThat(field.filter?.type.toString()).isEqualTo(sourceReportField.filter?.type.toString())
+    assertThat(field.filter?.staticOptions).isNotEmpty
+    assertThat(field.filter?.staticOptions).hasSize(1)
+    assertThat(field.type.toString()).isEqualTo(sourceSchemaField.type.toString())
+
+    val filterOption = field.filter?.staticOptions?.first()
+    val sourceFilterOption = sourceReportField.filter?.staticOptions?.first()
+
+    assertThat(filterOption?.name).isEqualTo(sourceFilterOption?.name)
+    assertThat(filterOption?.displayName).isEqualTo(sourceFilterOption?.displayName)
+  }
+
+  @Test
+  fun `Getting report list for user maps minimal data successfully`() {
+    val productDefinition = ProductDefinition(
+      id = "1",
+      name = "2",
+      metaData = MetaData(
+        author = "3",
+        owner = "4",
+        version = "5",
+      ),
+    )
+    val mapper = ReportDefinitionMapper()
+
+    val result = mapper.map(productDefinition, null)
+
+    assertThat(result).isNotNull
+    assertThat(result.variants).hasSize(0)
+  }
+
+  @Test
+  fun `Getting report list for user fails when mapping report with no matching dataset`() {
+    val productDefinition = ProductDefinition(
+      id = "1",
+      name = "2",
+      metaData = MetaData(
+        author = "3",
+        owner = "4",
+        version = "5",
+      ),
+      report = listOf(
+        Report(
+          id = "6",
+          name = "7",
+          created = LocalDate.MAX,
+          version = "8",
+          dataset = "\$ref:9",
+          render = RenderMethod.SVG,
+        ),
+      ),
+    )
+    val mapper = ReportDefinitionMapper()
+
+    val exception = assertThrows(IllegalArgumentException::class.java) {
+      mapper.map(productDefinition, null)
+    }
+
+    assertThat(exception).message().isEqualTo("Could not find matching DataSet '9'")
+  }
+
+  @Test
+  fun `Getting HTML report list returns relevant reports`() {
+    val productDefinition = ProductDefinition(
+      id = "1",
+      name = "2",
+      metaData = MetaData(
+        author = "3",
+        owner = "4",
+        version = "5",
+      ),
+      dataSet = listOf(
+        DataSet(
+          id = "10",
+          name = "11",
+          query = "12",
+          schema = Schema(
+            field = emptyList(),
+          ),
+        ),
+      ),
+      report = listOf(
+        Report(
+          id = "13",
+          name = "14",
+          created = LocalDate.MAX,
+          version = "15",
+          dataset = "\$ref:10",
+          render = RenderMethod.SVG,
+        ),
+        Report(
+          id = "16",
+          name = "17",
+          created = LocalDate.MAX,
+          version = "18",
+          dataset = "\$ref:10",
+          render = RenderMethod.HTML,
+        ),
+      ),
+    )
+    val mapper = ReportDefinitionMapper()
+
+    val result = mapper.map(productDefinition, HTML)
+
+    assertThat(result).isNotNull
+    assertThat(result.variants).hasSize(1)
+    assertThat(result.variants.first().id).isEqualTo("16")
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/service/ReportDefinitionMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/service/ReportDefinitionMapperTest.kt
@@ -3,6 +3,8 @@ package uk.gov.justice.digital.hmpps.digitalprisonreportingmi.service
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
 import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.controller.model.RenderMethod.HTML
 import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model.DataSet
 import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model.DataSource
@@ -20,6 +22,8 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model.SchemaFi
 import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model.Specification
 import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model.WordWrap
 import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import java.time.temporal.ChronoUnit
 import java.util.Collections.singletonMap
 
 class ReportDefinitionMapperTest {
@@ -237,5 +241,109 @@ class ReportDefinitionMapperTest {
     assertThat(result).isNotNull
     assertThat(result.variants).hasSize(1)
     assertThat(result.variants.first().id).isEqualTo("16")
+  }
+
+  @ParameterizedTest
+  @CsvSource(
+    "-2,DAYS",
+    "-1,DAYS",
+    "0,DAYS",
+    "1,DAYS",
+    "2,DAYS",
+    "2,WEEKS",
+    "2,MONTHS",
+    "2,YEARS",
+  )
+  fun `Default value token is mapped correctly`(offset: Long, magnitude: ChronoUnit) {
+    val defaultValue = createProductDefinitionWithDefaultFilter("today($offset, $magnitude)")
+    val expectedDate = getExpectedDate(offset, magnitude)
+
+    val result = ReportDefinitionMapper().map(defaultValue, HTML)
+
+    assertThat(result.variants[0].specification!!.fields[0].filter!!.defaultValue).isEqualTo(expectedDate)
+  }
+
+  @Test
+  fun `Default value token for today is mapped correctly`() {
+    val defaultValue = createProductDefinitionWithDefaultFilter("today()")
+    val expectedDate = LocalDate.now().format(DateTimeFormatter.ISO_LOCAL_DATE)
+
+    val result = ReportDefinitionMapper().map(defaultValue, HTML)
+
+    assertThat(result.variants[0].specification!!.fields[0].filter!!.defaultValue).isEqualTo(expectedDate)
+  }
+
+  @Test
+  fun `Multiple default value tokens are mapped correctly`() {
+    val defaultValue = createProductDefinitionWithDefaultFilter("today(-7,DAYS), today(), today(7,DAYS)")
+    val expectedDate1 = getExpectedDate(-7, ChronoUnit.DAYS)
+    val expectedDate2 = LocalDate.now().format(DateTimeFormatter.ISO_LOCAL_DATE)
+    val expectedDate3 = getExpectedDate(7, ChronoUnit.DAYS)
+    val expectedResult = "$expectedDate1, $expectedDate2, $expectedDate3"
+
+    val result = ReportDefinitionMapper().map(defaultValue, HTML)
+
+    assertThat(result.variants[0].specification!!.fields[0].filter!!.defaultValue).isEqualTo(expectedResult)
+  }
+
+  private fun getExpectedDate(offset: Long, magnitude: ChronoUnit): String? {
+    val expectedDate = when (magnitude) {
+      ChronoUnit.DAYS -> LocalDate.now().plusDays(offset)
+      ChronoUnit.WEEKS -> LocalDate.now().plusWeeks(offset)
+      ChronoUnit.MONTHS -> LocalDate.now().plusMonths(offset)
+      ChronoUnit.YEARS -> LocalDate.now().plusYears(offset)
+      else -> null
+    }.let { it!!.format(DateTimeFormatter.ISO_LOCAL_DATE) }
+    return expectedDate
+  }
+
+  private fun createProductDefinitionWithDefaultFilter(defaultFilterValue: String): ProductDefinition {
+    return ProductDefinition(
+      id = "1",
+      name = "2",
+      metaData = MetaData(
+        author = "3",
+        owner = "4",
+        version = "5",
+      ),
+      dataSet = listOf(
+        DataSet(
+          id = "10",
+          name = "11",
+          query = "12",
+          schema = Schema(
+            field = listOf(
+              SchemaField(
+                name = "13",
+                type = ParameterType.Date,
+              ),
+            ),
+          ),
+        ),
+      ),
+      report = listOf(
+        Report(
+          id = "16",
+          name = "17",
+          created = LocalDate.MAX,
+          version = "18",
+          dataset = "\$ref:10",
+          render = RenderMethod.HTML,
+          specification = Specification(
+            template = "19",
+            field = listOf(
+              ReportField(
+                schemaField = "\$ref:13",
+                displayName = "20",
+                filter = FilterDefinition(
+                  type = FilterType.DateRange,
+                  defaultValue = defaultFilterValue,
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    )
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/service/ReportDefinitionServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/service/ReportDefinitionServiceTest.kt
@@ -14,11 +14,14 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model.FilterDe
 import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model.FilterOption
 import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model.FilterType
 import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model.MetaData
-import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model.Parameter
 import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model.ParameterType
 import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model.ProductDefinition
 import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model.RenderMethod
 import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model.Report
+import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model.ReportField
+import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model.Schema
+import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model.SchemaField
+import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model.Specification
 import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model.WordWrap
 import java.time.LocalDate
 import java.util.Collections.singletonMap
@@ -42,24 +45,12 @@ class ReportDefinitionServiceTest {
         id = "10",
         name = "11",
         query = "12",
-        parameters = listOf(
-          Parameter(
-            name = "13",
-            displayName = "14",
-            type = ParameterType.Long,
-            dateFormat = "15",
-            wordWrap = WordWrap.None,
-            filter = FilterDefinition(
-              type = FilterType.Radio,
-              staticOptions = listOf(
-                FilterOption(
-                  name = "16",
-                  displayName = "17",
-                ),
-              ),
+        schema = Schema(
+          field = listOf(
+            SchemaField(
+              name = "13",
+              type = ParameterType.Long,
             ),
-            sortable = true,
-            defaultSortColumn = true,
           ),
         ),
       ),
@@ -82,7 +73,27 @@ class ReportDefinitionServiceTest {
         policy = listOf("25"),
         render = RenderMethod.PDF,
         schedule = "26",
-        specification = "27",
+        specification = Specification(
+          template = "27",
+          field = listOf(
+            ReportField(
+              schemaField = "\$ref:13",
+              displayName = "14",
+              wordWrap = WordWrap.None,
+              filter = FilterDefinition(
+                type = FilterType.Radio,
+                staticOptions = listOf(
+                  FilterOption(
+                    name = "16",
+                    displayName = "17",
+                  ),
+                ),
+              ),
+              sortable = true,
+              defaultSortColumn = true,
+            ),
+          ),
+        ),
         destination = listOf(singletonMap("28", "29")),
       ),
     ),
@@ -118,27 +129,28 @@ class ReportDefinitionServiceTest {
     assertThat(variant.resourceName).isEqualTo(fullProductDefinition.dataSet.first().id)
     assertThat(variant.resourceName).isEqualTo(fullProductDefinition.dataSet.first().id)
     assertThat(variant.description).isEqualTo(fullProductDefinition.report.first().description)
-    assertThat(variant.specification).isEqualTo(fullProductDefinition.report.first().specification)
-    assertThat(variant.fields).isNotEmpty
-    assertThat(variant.fields).hasSize(1)
+    assertThat(variant.specification).isNotNull
+    assertThat(variant.specification?.template).isEqualTo(fullProductDefinition.report.first().specification?.template)
+    assertThat(variant.specification?.fields).isNotEmpty
+    assertThat(variant.specification?.fields).hasSize(1)
 
-    val field = variant.fields.first()
-    val sourceParameter = fullProductDefinition.dataSet.first().parameters.first()
+    val field = variant.specification!!.fields.first()
+    val sourceSchemaField = fullProductDefinition.dataSet.first().schema.field.first()
+    val sourceReportField = fullProductDefinition.report.first().specification!!.field.first()
 
-    assertThat(field.name).isEqualTo(sourceParameter.name)
-    assertThat(field.displayName).isEqualTo(sourceParameter.displayName)
-    assertThat(field.dateFormat).isEqualTo(sourceParameter.dateFormat)
-    assertThat(field.wordWrap.toString()).isEqualTo(sourceParameter.wordWrap.toString())
-    assertThat(field.sortable).isEqualTo(sourceParameter.sortable)
-    assertThat(field.defaultSortColumn).isEqualTo(sourceParameter.defaultSortColumn)
+    assertThat(field.name).isEqualTo(sourceSchemaField.name)
+    assertThat(field.displayName).isEqualTo(sourceReportField.displayName)
+    assertThat(field.wordWrap.toString()).isEqualTo(sourceReportField.wordWrap.toString())
+    assertThat(field.sortable).isEqualTo(sourceReportField.sortable)
+    assertThat(field.defaultSortColumn).isEqualTo(sourceReportField.defaultSortColumn)
     assertThat(field.filter).isNotNull
-    assertThat(field.filter?.type.toString()).isEqualTo(sourceParameter.filter?.type.toString())
+    assertThat(field.filter?.type.toString()).isEqualTo(sourceReportField.filter?.type.toString())
     assertThat(field.filter?.staticOptions).isNotEmpty
     assertThat(field.filter?.staticOptions).hasSize(1)
-    assertThat(field.type.toString()).isEqualTo(sourceParameter.type.toString())
+    assertThat(field.type.toString()).isEqualTo(sourceSchemaField.type.toString())
 
     val filterOption = field.filter?.staticOptions?.first()
-    val sourceFilterOption = sourceParameter.filter?.staticOptions?.first()
+    val sourceFilterOption = sourceReportField.filter?.staticOptions?.first()
 
     assertThat(filterOption?.name).isEqualTo(sourceFilterOption?.name)
     assertThat(filterOption?.displayName).isEqualTo(sourceFilterOption?.displayName)
@@ -219,7 +231,9 @@ class ReportDefinitionServiceTest {
               id = "10",
               name = "11",
               query = "12",
-              parameters = emptyList(),
+              schema = Schema(
+                field = emptyList(),
+              ),
             ),
           ),
           report = listOf(
@@ -269,7 +283,9 @@ class ReportDefinitionServiceTest {
               id = "10",
               name = "11",
               query = "12",
-              parameters = emptyList(),
+              schema = Schema(
+                field = emptyList(),
+              ),
             ),
           ),
           report = listOf(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/service/ReportDefinitionServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/service/ReportDefinitionServiceTest.kt
@@ -105,6 +105,7 @@ class ReportDefinitionServiceTest {
     val definition = result.first()
 
     assertThat(definition).isNotNull
+    assertThat(definition.id).isEqualTo(fullProductDefinition.id)
     assertThat(definition.name).isEqualTo(fullProductDefinition.name)
     assertThat(definition.description).isEqualTo(fullProductDefinition.description)
     assertThat(definition.variants).isNotEmpty
@@ -134,6 +135,7 @@ class ReportDefinitionServiceTest {
     assertThat(field.filter?.type.toString()).isEqualTo(sourceParameter.filter?.type.toString())
     assertThat(field.filter?.staticOptions).isNotEmpty
     assertThat(field.filter?.staticOptions).hasSize(1)
+    assertThat(field.type.toString()).isEqualTo(sourceParameter.type.toString())
 
     val filterOption = field.filter?.staticOptions?.first()
     val sourceFilterOption = sourceParameter.filter?.staticOptions?.first()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/service/ReportDefinitionServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/service/ReportDefinitionServiceTest.kt
@@ -1,310 +1,80 @@
 package uk.gov.justice.digital.hmpps.digitalprisonreportingmi.service
 
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.then
-import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.controller.model.RenderMethod.HTML
+import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.controller.model.RenderMethod
+import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.controller.model.ReportDefinition
+import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.controller.model.VariantDefinition
 import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.ProductDefinitionRepository
-import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model.DataSet
-import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model.DataSource
-import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model.FilterDefinition
-import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model.FilterOption
-import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model.FilterType
 import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model.MetaData
-import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model.ParameterType
 import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model.ProductDefinition
-import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model.RenderMethod
-import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model.Report
-import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model.ReportField
-import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model.Schema
-import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model.SchemaField
-import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model.Specification
-import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.model.WordWrap
-import java.time.LocalDate
-import java.util.Collections.singletonMap
 
 class ReportDefinitionServiceTest {
 
-  private val fullProductDefinition: ProductDefinition = ProductDefinition(
+  val minimalDefinition = ProductDefinition(
     id = "1",
     name = "2",
-    description = "3",
     metaData = MetaData(
-      author = "4",
+      author = "3",
+      owner = "4",
       version = "5",
-      owner = "6",
-      purpose = "7",
-      profile = "8",
-      dqri = "9",
     ),
-    dataSet = listOf(
-      DataSet(
-        id = "10",
-        name = "11",
-        query = "12",
-        schema = Schema(
-          field = listOf(
-            SchemaField(
-              name = "13",
-              type = ParameterType.Long,
-            ),
-          ),
-        ),
-      ),
-    ),
-    dataSource = listOf(
-      DataSource(
-        id = "18",
-        name = "19",
-        connection = "20",
-      ),
-    ),
-    report = listOf(
-      Report(
-        id = "21",
-        name = "22",
-        description = "23",
-        created = LocalDate.MAX,
-        version = "24",
-        dataset = "\$ref:10",
-        policy = listOf("25"),
-        render = RenderMethod.PDF,
-        schedule = "26",
-        specification = Specification(
-          template = "27",
-          field = listOf(
-            ReportField(
-              schemaField = "\$ref:13",
-              displayName = "14",
-              wordWrap = WordWrap.None,
-              filter = FilterDefinition(
-                type = FilterType.Radio,
-                staticOptions = listOf(
-                  FilterOption(
-                    name = "16",
-                    displayName = "17",
-                  ),
-                ),
-              ),
-              sortable = true,
-              defaultSortColumn = true,
-            ),
-          ),
-        ),
-        destination = listOf(singletonMap("28", "29")),
-      ),
-    ),
+    report = emptyList(),
   )
 
   @Test
-  fun `Getting report list for user maps full data correctly`() {
-    val repository = mock<ProductDefinitionRepository> {
-      on { getProductDefinitions() } doReturn listOf(fullProductDefinition)
-    }
-    val service = ReportDefinitionService(repository)
+  fun `Getting report list for user maps correctly`() {
+    val expectedResult = ReportDefinition(
+      id = "1",
+      name = "2",
+      variants = listOf(
+        VariantDefinition(
+          id = "1",
+          name = "2",
+          resourceName = "3",
+        ),
+      ),
+    )
 
-    val result = service.getListForUser(null)
+    val repository = mock<ProductDefinitionRepository> {
+      on { getProductDefinitions() } doReturn listOf(minimalDefinition)
+    }
+    val mapper = mock<ReportDefinitionMapper> {
+      on { map(any(), any()) } doReturn expectedResult
+    }
+    val service = ReportDefinitionService(repository, mapper)
+
+    val actualResult = service.getListForUser(RenderMethod.HTML)
 
     then(repository).should().getProductDefinitions()
+    then(mapper).should().map(minimalDefinition, RenderMethod.HTML)
 
-    assertThat(result).isNotEmpty
-    assertThat(result).hasSize(1)
-
-    val definition = result.first()
-
-    assertThat(definition).isNotNull
-    assertThat(definition.id).isEqualTo(fullProductDefinition.id)
-    assertThat(definition.name).isEqualTo(fullProductDefinition.name)
-    assertThat(definition.description).isEqualTo(fullProductDefinition.description)
-    assertThat(definition.variants).isNotEmpty
-    assertThat(definition.variants).hasSize(1)
-
-    val variant = definition.variants.first()
-
-    assertThat(variant.id).isEqualTo(fullProductDefinition.report.first().id)
-    assertThat(variant.name).isEqualTo(fullProductDefinition.report.first().name)
-    assertThat(variant.resourceName).isEqualTo(fullProductDefinition.dataSet.first().id)
-    assertThat(variant.resourceName).isEqualTo(fullProductDefinition.dataSet.first().id)
-    assertThat(variant.description).isEqualTo(fullProductDefinition.report.first().description)
-    assertThat(variant.specification).isNotNull
-    assertThat(variant.specification?.template).isEqualTo(fullProductDefinition.report.first().specification?.template)
-    assertThat(variant.specification?.fields).isNotEmpty
-    assertThat(variant.specification?.fields).hasSize(1)
-
-    val field = variant.specification!!.fields.first()
-    val sourceSchemaField = fullProductDefinition.dataSet.first().schema.field.first()
-    val sourceReportField = fullProductDefinition.report.first().specification!!.field.first()
-
-    assertThat(field.name).isEqualTo(sourceSchemaField.name)
-    assertThat(field.displayName).isEqualTo(sourceReportField.displayName)
-    assertThat(field.wordWrap.toString()).isEqualTo(sourceReportField.wordWrap.toString())
-    assertThat(field.sortable).isEqualTo(sourceReportField.sortable)
-    assertThat(field.defaultSortColumn).isEqualTo(sourceReportField.defaultSortColumn)
-    assertThat(field.filter).isNotNull
-    assertThat(field.filter?.type.toString()).isEqualTo(sourceReportField.filter?.type.toString())
-    assertThat(field.filter?.staticOptions).isNotEmpty
-    assertThat(field.filter?.staticOptions).hasSize(1)
-    assertThat(field.type.toString()).isEqualTo(sourceSchemaField.type.toString())
-
-    val filterOption = field.filter?.staticOptions?.first()
-    val sourceFilterOption = sourceReportField.filter?.staticOptions?.first()
-
-    assertThat(filterOption?.name).isEqualTo(sourceFilterOption?.name)
-    assertThat(filterOption?.displayName).isEqualTo(sourceFilterOption?.displayName)
-  }
-
-  @Test
-  fun `Getting report list for user maps minimal data successfully`() {
-    val repository = mock<ProductDefinitionRepository> {
-      on { getProductDefinitions() } doReturn listOf(
-        ProductDefinition(
-          id = "1",
-          name = "2",
-          metaData = MetaData(
-            author = "3",
-            owner = "4",
-            version = "5",
-          ),
-        ),
-      )
-    }
-    val service = ReportDefinitionService(repository)
-
-    val result = service.getListForUser(null)
-
-    then(repository).should().getProductDefinitions()
-
-    assertThat(result).isEmpty()
-  }
-
-  @Test
-  fun `Getting report list for user fails when mapping report with no matching dataset`() {
-    val repository = mock<ProductDefinitionRepository> {
-      on { getProductDefinitions() } doReturn listOf(
-        ProductDefinition(
-          id = "1",
-          name = "2",
-          metaData = MetaData(
-            author = "3",
-            owner = "4",
-            version = "5",
-          ),
-          report = listOf(
-            Report(
-              id = "6",
-              name = "7",
-              created = LocalDate.MAX,
-              version = "8",
-              dataset = "\$ref:9",
-              render = RenderMethod.SVG,
-            ),
-          ),
-        ),
-      )
-    }
-    val service = ReportDefinitionService(repository)
-
-    val exception = assertThrows(IllegalArgumentException::class.java) {
-      service.getListForUser(null)
-    }
-
-    assertThat(exception).message().isEqualTo("Could not find matching DataSet '9'")
-  }
-
-  @Test
-  fun `Getting HTML report list returns relevant reports`() {
-    val repository = mock<ProductDefinitionRepository> {
-      on { getProductDefinitions() } doReturn listOf(
-        ProductDefinition(
-          id = "1",
-          name = "2",
-          metaData = MetaData(
-            author = "3",
-            owner = "4",
-            version = "5",
-          ),
-          dataSet = listOf(
-            DataSet(
-              id = "10",
-              name = "11",
-              query = "12",
-              schema = Schema(
-                field = emptyList(),
-              ),
-            ),
-          ),
-          report = listOf(
-            Report(
-              id = "13",
-              name = "14",
-              created = LocalDate.MAX,
-              version = "15",
-              dataset = "\$ref:10",
-              render = RenderMethod.SVG,
-            ),
-            Report(
-              id = "16",
-              name = "17",
-              created = LocalDate.MAX,
-              version = "18",
-              dataset = "\$ref:10",
-              render = RenderMethod.HTML,
-            ),
-          ),
-        ),
-      )
-    }
-    val service = ReportDefinitionService(repository)
-
-    val result = service.getListForUser(HTML)
-
-    assertThat(result).hasSize(1)
-    assertThat(result.first().variants).hasSize(1)
-    assertThat(result.first().variants.first().id).isEqualTo("16")
+    assertThat(actualResult).isNotEmpty
+    assertThat(actualResult).hasSize(1)
+    assertThat(actualResult[0]).isEqualTo(expectedResult)
   }
 
   @Test
   fun `Getting HTML report list with no matches returns no domains`() {
+    val definitionWithNoVariants = ReportDefinition(
+      id = "1",
+      name = "2",
+      variants = emptyList(),
+    )
     val repository = mock<ProductDefinitionRepository> {
-      on { getProductDefinitions() } doReturn listOf(
-        ProductDefinition(
-          id = "1",
-          name = "2",
-          metaData = MetaData(
-            author = "3",
-            owner = "4",
-            version = "5",
-          ),
-          dataSet = listOf(
-            DataSet(
-              id = "10",
-              name = "11",
-              query = "12",
-              schema = Schema(
-                field = emptyList(),
-              ),
-            ),
-          ),
-          report = listOf(
-            Report(
-              id = "13",
-              name = "14",
-              created = LocalDate.MAX,
-              version = "15",
-              dataset = "\$ref:10",
-              render = RenderMethod.SVG,
-            ),
-          ),
-        ),
-      )
+      on { getProductDefinitions() } doReturn listOf(minimalDefinition)
     }
-    val service = ReportDefinitionService(repository)
+    val mapper = mock<ReportDefinitionMapper> {
+      on { map(any(), any()) } doReturn definitionWithNoVariants
+    }
+    val service = ReportDefinitionService(repository, mapper)
 
-    val result = service.getListForUser(HTML)
+    val actualResult = service.getListForUser(RenderMethod.HTML)
 
-    assertThat(result).hasSize(0)
+    assertThat(actualResult).hasSize(0)
   }
 }


### PR DESCRIPTION
- Move report-specific data out of dataset.
- Add fields: ReportDefinition.id, FieldDefinition.type, FilterDefinition.defaultValue.
- Add default value 'today' token mapping.