### PR TITLE
Fix Redshift query

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/data/StubbedProductDefinitionRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/data/StubbedProductDefinitionRepository.kt
@@ -69,7 +69,7 @@ class StubbedProductDefinitionRepository : ProductDefinitionRepository {
             name = "All movements",
             query = "SELECT " +
               "prisoners.number AS prisonNumber," +
-              "CONCAT(prisoners.lastname, ', ', substring(prisoners.firstname, 1, 1)) AS name," +
+              "CONCAT(CONCAT(prisoners.lastname, ', '), substring(prisoners.firstname, 1, 1)) AS name," +
               "movements.date," +
               "movements.direction," +
               "movements.type," +

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/service/ConfiguredApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/service/ConfiguredApiService.kt
@@ -17,7 +17,8 @@ class ConfiguredApiService(
 ) {
 
   companion object {
-    const val INVALID_REPORT_ID_MESSAGE = "Invalid report id provided."
+    const val INVALID_REPORT_ID_MESSAGE = "Invalid report id provided:"
+    const val INVALID_REPORT_VARIANT_ID_MESSAGE = "Invalid report variant id provided:"
     const val INVALID_FILTERS_MESSAGE = "Invalid filters provided."
     const val INVALID_STATIC_OPTIONS_MESSAGE = "Invalid static options provided."
     private const val schemaRefPrefix = "\$ref:"
@@ -155,8 +156,9 @@ class ConfiguredApiService(
   private fun getReportVariant(reportId: String, reportVariantId: String) =
     stubbedProductDefinitionRepository.getProductDefinitions()
       .filter { it.id == reportId }
+      .ifEmpty { throw ValidationException("$INVALID_REPORT_ID_MESSAGE $reportId") }
       .flatMap { it.report.filter { report -> report.id == reportVariantId } }
-      .ifEmpty { throw ValidationException(INVALID_REPORT_ID_MESSAGE) }
+      .ifEmpty { throw ValidationException("$INVALID_REPORT_VARIANT_ID_MESSAGE $reportVariantId") }
       .first()
 
   private fun truncateRangeFilters(filters: Map<String, String>): Map<String, String> {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/service/ConfiguredApiServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/service/ConfiguredApiServiceTest.kt
@@ -129,6 +129,23 @@ class ConfiguredApiServiceTest {
   }
 
   @Test
+  fun `should throw an exception for invalid report id`() {
+    val reportId = "random report id"
+    val reportVariantId = "last-month"
+    val filters = mapOf("direction" to "in", "date.start" to "2023-04-25", "date.end" to "2023-09-10")
+    val selectedPage = 1L
+    val pageSize = 10L
+    val sortColumn = "date"
+    val sortedAsc = true
+
+    val e = org.junit.jupiter.api.assertThrows<ValidationException> {
+      configuredApiService.validateAndFetchData(reportId, reportVariantId, filters, selectedPage, pageSize, sortColumn, sortedAsc)
+    }
+    assertEquals("${ConfiguredApiService.INVALID_REPORT_ID_MESSAGE} $reportId", e.message)
+    verify(configuredApiRepository, times(0)).executeQuery(any(), any(), any(), any(), any(), any(), any())
+  }
+
+  @Test
   fun `should throw an exception for invalid report variant`() {
     val reportId = "external-movements"
     val reportVariantId = "non existent variant"
@@ -141,7 +158,7 @@ class ConfiguredApiServiceTest {
     val e = org.junit.jupiter.api.assertThrows<ValidationException> {
       configuredApiService.validateAndFetchData(reportId, reportVariantId, filters, selectedPage, pageSize, sortColumn, sortedAsc)
     }
-    assertEquals(ConfiguredApiService.INVALID_REPORT_ID_MESSAGE, e.message)
+    assertEquals("${ConfiguredApiService.INVALID_REPORT_VARIANT_ID_MESSAGE} $reportVariantId", e.message)
     verify(configuredApiRepository, times(0)).executeQuery(any(), any(), any(), any(), any(), any(), any())
   }
 


### PR DESCRIPTION
This PR:
- Fixes concat function of the Redshift query. This function takes two parameters on Redshift and we have been passing three resulting into an error.
- Separates cases for invalid report id and invalid report variant id