### PR TITLE
DPR2-64 Fix path conflicts

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/controller/ConfiguredApiController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/controller/ConfiguredApiController.kt
@@ -21,7 +21,7 @@ class ConfiguredApiController(val configuredApiService: ConfiguredApiService) {
     const val FILTERS_PREFIX = "filters."
   }
 
-  @GetMapping("/{reportId}/{reportVariantId}")
+  @GetMapping("/reports/{reportId}/{reportVariantId}")
   @Operation(
     description = "Returns the dataset for the given report ID and report variant ID filtered by the filters provided in the query.",
     security = [ SecurityRequirement(name = "bearer-jwt") ],

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/service/ReportDefinitionMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/service/ReportDefinitionMapper.kt
@@ -45,7 +45,7 @@ class ReportDefinitionMapper {
       name = report.name,
       description = report.description,
       specification = map(report.specification, dataSet.schema.field),
-      resourceName = "$productDefinitionId/${report.id}",
+      resourceName = "reports/$productDefinitionId/${report.id}",
     )
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/integration/ConfiguredApiIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/integration/ConfiguredApiIntegrationTest.kt
@@ -50,7 +50,7 @@ class ConfiguredApiIntegrationTest : IntegrationTestBase() {
     webTestClient.get()
       .uri { uriBuilder: UriBuilder ->
         uriBuilder
-          .path("/external-movements/last-month")
+          .path("/reports/external-movements/last-month")
           .queryParam("selectedPage", 1)
           .queryParam("pageSize", 3)
           .queryParam("sortColumn", "date")
@@ -77,7 +77,7 @@ class ConfiguredApiIntegrationTest : IntegrationTestBase() {
     webTestClient.get()
       .uri { uriBuilder: UriBuilder ->
         uriBuilder
-          .path("/external-movements/last-month")
+          .path("/reports/external-movements/last-month")
           .queryParam("${FILTERS_PREFIX}date.start", "2023-04-25")
           .queryParam("${FILTERS_PREFIX}date.end", "2023-05-20")
           .queryParam("${FILTERS_PREFIX}direction", "out")
@@ -101,7 +101,7 @@ class ConfiguredApiIntegrationTest : IntegrationTestBase() {
     webTestClient.get()
       .uri { uriBuilder: UriBuilder ->
         uriBuilder
-          .path("/external-movements/last-month")
+          .path("/reports/external-movements/last-month")
           .build()
       }
       .headers(setAuthorisation(roles = listOf(authorisedRole)))
@@ -134,7 +134,7 @@ class ConfiguredApiIntegrationTest : IntegrationTestBase() {
     val results = webTestClient.get()
       .uri { uriBuilder: UriBuilder ->
         uriBuilder
-          .path("/external-movements/last-month")
+          .path("/reports/external-movements/last-month")
           .queryParam("${FILTERS_PREFIX}direction", direction)
           .build()
       }
@@ -156,47 +156,47 @@ class ConfiguredApiIntegrationTest : IntegrationTestBase() {
 
   @Test
   fun `Configured API returns 400 for invalid selectedPage query param`() {
-    requestWithQueryAndAssert400("selectedPage", 0, "/external-movements/last-month")
+    requestWithQueryAndAssert400("selectedPage", 0, "/reports/external-movements/last-month")
   }
 
   @Test
   fun `Configured API returns 400 for invalid pageSize query param`() {
-    requestWithQueryAndAssert400("pageSize", 0, "/external-movements/last-month")
+    requestWithQueryAndAssert400("pageSize", 0, "/reports/external-movements/last-month")
   }
 
   @Test
   fun `Configured API returns 400 for invalid (wrong type) pageSize query param`() {
-    requestWithQueryAndAssert400("pageSize", "a", "/external-movements/last-month")
+    requestWithQueryAndAssert400("pageSize", "a", "/reports/external-movements/last-month")
   }
 
   @Test
   fun `Configured API returns 400 for invalid sortColumn query param`() {
-    requestWithQueryAndAssert400("sortColumn", "nonExistentColumn", "/external-movements/last-month")
+    requestWithQueryAndAssert400("sortColumn", "nonExistentColumn", "/reports/external-movements/last-month")
   }
 
   @Test
   fun `Configured API returns 400 for invalid sortedAsc query param`() {
-    requestWithQueryAndAssert400("sortedAsc", "abc", "/external-movements/last-month")
+    requestWithQueryAndAssert400("sortedAsc", "abc", "/reports/external-movements/last-month")
   }
 
   @Test
   fun `Configured API returns 400 for non-existent filter`() {
-    requestWithQueryAndAssert400("${FILTERS_PREFIX}abc", "abc", "/external-movements/last-month")
+    requestWithQueryAndAssert400("${FILTERS_PREFIX}abc", "abc", "/reports/external-movements/last-month")
   }
 
   @Test
   fun `Configured API returns 400 for a report field which is not a filter`() {
-    requestWithQueryAndAssert400("${FILTERS_PREFIX}name", "some name", "/external-movements/last-month")
+    requestWithQueryAndAssert400("${FILTERS_PREFIX}name", "some name", "/reports/external-movements/last-month")
   }
 
   @Test
   fun `Configured API returns 400 for invalid startDate query param`() {
-    requestWithQueryAndAssert400("${FILTERS_PREFIX}date.start", "abc", "/external-movements/last-month")
+    requestWithQueryAndAssert400("${FILTERS_PREFIX}date.start", "abc", "/reports/external-movements/last-month")
   }
 
   @Test
   fun `External movements returns 400 for invalid endDate query param`() {
-    requestWithQueryAndAssert400("${FILTERS_PREFIX}date.end", "b", "/external-movements/last-month")
+    requestWithQueryAndAssert400("${FILTERS_PREFIX}date.end", "b", "/reports/external-movements/last-month")
   }
 
   private fun requestWithQueryAndAssert400(paramName: String, paramValue: Any, path: String) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/integration/ReportDefinitionIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/integration/ReportDefinitionIntegrationTest.kt
@@ -34,7 +34,7 @@ class ReportDefinitionIntegrationTest : IntegrationTestBase() {
     val lastMonthVariant = definition.variants[0]
 
     assertThat(lastMonthVariant.id).isEqualTo("last-month")
-    assertThat(lastMonthVariant.resourceName).isEqualTo("external-movements/last-month")
+    assertThat(lastMonthVariant.resourceName).isEqualTo("reports/external-movements/last-month")
     assertThat(lastMonthVariant.name).isEqualTo("Last month")
     assertThat(lastMonthVariant.description).isEqualTo("All movements in the past month")
     assertThat(lastMonthVariant.specification).isNotNull
@@ -42,7 +42,7 @@ class ReportDefinitionIntegrationTest : IntegrationTestBase() {
 
     val lastWeekVariant = definition.variants[1]
     assertThat(lastWeekVariant.id).isEqualTo("last-week")
-    assertThat(lastWeekVariant.resourceName).isEqualTo("external-movements/last-week")
+    assertThat(lastWeekVariant.resourceName).isEqualTo("reports/external-movements/last-week")
     assertThat(lastWeekVariant.description).isEqualTo("All movements in the past week")
     assertThat(lastWeekVariant.name).isEqualTo("Last week")
     assertThat(lastWeekVariant.specification).isNotNull

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/service/ReportDefinitionMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/service/ReportDefinitionMapperTest.kt
@@ -116,7 +116,7 @@ class ReportDefinitionMapperTest {
 
     assertThat(variant.id).isEqualTo(fullProductDefinition.report.first().id)
     assertThat(variant.name).isEqualTo(fullProductDefinition.report.first().name)
-    assertThat(variant.resourceName).isEqualTo("${fullProductDefinition.id}/${fullProductDefinition.report.first().id}")
+    assertThat(variant.resourceName).isEqualTo("reports/${fullProductDefinition.id}/${fullProductDefinition.report.first().id}")
     assertThat(variant.description).isEqualTo(fullProductDefinition.report.first().description)
     assertThat(variant.specification).isNotNull
     assertThat(variant.specification?.template).isEqualTo(fullProductDefinition.report.first().specification?.template)


### PR DESCRIPTION
This PR adds "reports/" prefix to the ConfiguredApiController path to avoid conflicts with other paths like Swagger and the Definition API.