### PR TITLE
DPR2-125 Swagger documentation improvements and refactoring.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/controller/ConfiguredApiController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/controller/ConfiguredApiController.kt
@@ -11,6 +11,8 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.controller.ConfiguredApiController.FiltersPrefix.FILTERS_PREFIX
+import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.controller.ConfiguredApiController.FiltersPrefix.FILTERS_QUERY_DESCRIPTION
+import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.controller.ConfiguredApiController.FiltersPrefix.FILTERS_QUERY_EXAMPLE
 import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.controller.model.Count
 import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.service.ConfiguredApiService
 
@@ -20,6 +22,15 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.service.ConfiguredA
 class ConfiguredApiController(val configuredApiService: ConfiguredApiService) {
   object FiltersPrefix {
     const val FILTERS_PREFIX = "filters."
+    const val RANGE_FILTER_START_SUFFIX = ".start"
+    const val RANGE_FILTER_END_SUFFIX = ".end"
+    const val FILTERS_QUERY_DESCRIPTION = """The filter query parameters have to start with the prefix "$FILTERS_PREFIX" followed by the name of the filter.
+      |For range filters, like date for instance, these need to be followed by a $RANGE_FILTER_START_SUFFIX or $RANGE_FILTER_END_SUFFIX suffix accordingly.
+    """
+    const val FILTERS_QUERY_EXAMPLE = """{
+        "filters.date$RANGE_FILTER_START_SUFFIX": "2023-04-25",
+        "filters.date$RANGE_FILTER_END_SUFFIX": "2023-05-30"
+        }"""
   }
 
   @GetMapping("/reports/{reportId}/{reportVariantId}")
@@ -37,15 +48,15 @@ class ConfiguredApiController(val configuredApiService: ConfiguredApiService) {
     @RequestParam sortColumn: String?,
     @RequestParam(defaultValue = "false") sortedAsc: Boolean,
     @Parameter(
-      description = "The filter query parameters have to start with the prefix \"$FILTERS_PREFIX\" followed by the name of the filter.",
-      example = "filters.date.start=2023-04-25",
+      description = FILTERS_QUERY_DESCRIPTION,
+      example = FILTERS_QUERY_EXAMPLE,
     )
     @RequestParam
-    allQueryParams: Map<String, String>,
+    filters: Map<String, String>,
     @PathVariable("reportId") reportId: String,
     @PathVariable("reportVariantId") reportVariantId: String,
   ): List<Map<String, Any>> {
-    return configuredApiService.validateAndFetchData(reportId, reportVariantId, filtersOnly(allQueryParams), selectedPage, pageSize, sortColumn, sortedAsc)
+    return configuredApiService.validateAndFetchData(reportId, reportVariantId, filtersOnly(filters), selectedPage, pageSize, sortColumn, sortedAsc)
   }
 
   @GetMapping("/reports/{reportId}/{reportVariantId}/count")
@@ -55,15 +66,15 @@ class ConfiguredApiController(val configuredApiService: ConfiguredApiService) {
   )
   fun configuredApiCount(
     @Parameter(
-      description = "The filter query parameters have to start with the prefix \"$FILTERS_PREFIX\" followed by the name of the filter.",
-      example = "filters.date.start=2023-04-25",
+      description = FILTERS_QUERY_DESCRIPTION,
+      example = FILTERS_QUERY_EXAMPLE,
     )
     @RequestParam
-    allQueryParams: Map<String, String>,
+    filters: Map<String, String>,
     @PathVariable("reportId") reportId: String,
     @PathVariable("reportVariantId") reportVariantId: String,
   ): Count {
-    return configuredApiService.validateAndCount(reportId, reportVariantId, filtersOnly(allQueryParams))
+    return configuredApiService.validateAndCount(reportId, reportVariantId, filtersOnly(filters))
   }
 
   private fun filtersOnly(filters: Map<String, String>): Map<String, String> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/data/ConfiguredApiRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/data/ConfiguredApiRepository.kt
@@ -7,6 +7,8 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.controller.ConfiguredApiController.FiltersPrefix.RANGE_FILTER_END_SUFFIX
+import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.controller.ConfiguredApiController.FiltersPrefix.RANGE_FILTER_START_SUFFIX
 import java.sql.Timestamp
 
 @Service
@@ -81,10 +83,10 @@ class ConfiguredApiRepository {
 
   private fun buildWhereRangeCondition(rangeFilters: Map<String, String>) =
     rangeFilters.keys.joinToString(" AND ") { k ->
-      if (k.endsWith(".start")) {
-        "${k.removeSuffix(".start")} >= :$k"
-      } else if (k.endsWith(".end")) {
-        "${k.removeSuffix(".end")} <= :$k"
+      if (k.endsWith("$RANGE_FILTER_START_SUFFIX")) {
+        "${k.removeSuffix("$RANGE_FILTER_START_SUFFIX")} >= :$k"
+      } else if (k.endsWith("$RANGE_FILTER_END_SUFFIX")) {
+        "${k.removeSuffix("$RANGE_FILTER_END_SUFFIX")} <= :$k"
       } else {
         throw ValidationException("Range filter does not have a .start or .end suffix: $k")
       }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/service/ConfiguredApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/service/ConfiguredApiService.kt
@@ -2,6 +2,8 @@ package uk.gov.justice.digital.hmpps.digitalprisonreportingmi.service
 
 import jakarta.validation.ValidationException
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.controller.ConfiguredApiController.FiltersPrefix.RANGE_FILTER_END_SUFFIX
+import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.controller.ConfiguredApiController.FiltersPrefix.RANGE_FILTER_START_SUFFIX
 import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.controller.model.Count
 import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.ConfiguredApiRepository
 import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.StubbedProductDefinitionRepository
@@ -26,8 +28,6 @@ class ConfiguredApiService(
     private const val schemaRefPrefix = "\$ref:"
   }
 
-  val startSuffix = ".start"
-  val endSuffix = ".end"
   fun validateAndFetchData(
     reportId: String,
     reportVariantId: String,
@@ -39,7 +39,7 @@ class ConfiguredApiService(
   ): List<Map<String, Any>> {
     val dataSet = getDataSet(reportId, reportVariantId)
     validateFilters(reportId, reportVariantId, filters, dataSet)
-    val (rangeFilters, filtersExcludingRange) = filters.entries.partition { (k, _) -> k.endsWith(startSuffix) || k.endsWith(endSuffix) }
+    val (rangeFilters, filtersExcludingRange) = filters.entries.partition { (k, _) -> k.endsWith(RANGE_FILTER_START_SUFFIX) || k.endsWith(RANGE_FILTER_END_SUFFIX) }
     val validatedSortColumn = validateSortColumnOrGetDefault(sortColumn, reportId, dataSet, reportVariantId)
     return formatToSchemaFieldsCasing(
       configuredApiRepository
@@ -63,7 +63,7 @@ class ConfiguredApiService(
   ): Count {
     val dataSet = getDataSet(reportId, reportVariantId)
     validateFilters(reportId, reportVariantId, filters, dataSet)
-    val (rangeFilters, filtersExcludingRange) = filters.entries.partition { (k, _) -> k.endsWith(startSuffix) || k.endsWith(endSuffix) }
+    val (rangeFilters, filtersExcludingRange) = filters.entries.partition { (k, _) -> k.endsWith(RANGE_FILTER_START_SUFFIX) || k.endsWith(RANGE_FILTER_END_SUFFIX) }
     return Count(
       configuredApiRepository.count(
         rangeFilters.associate(transformMapEntryToPair()),
@@ -189,10 +189,10 @@ class ConfiguredApiService(
   }
 
   private fun truncateBasedOnSuffix(k: String, v: String): Pair<String, String> {
-    return if (k.endsWith(startSuffix)) {
-      k.substring(0, k.length - startSuffix.length) to v
-    } else if (k.endsWith(endSuffix)) {
-      k.substring(0, k.length - endSuffix.length) to v
+    return if (k.endsWith(RANGE_FILTER_START_SUFFIX)) {
+      k.substring(0, k.length - RANGE_FILTER_START_SUFFIX.length) to v
+    } else if (k.endsWith(RANGE_FILTER_END_SUFFIX)) {
+      k.substring(0, k.length - RANGE_FILTER_END_SUFFIX.length) to v
     } else {
       k to v
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/data/ConfiguredApiRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/data/ConfiguredApiRepositoryTest.kt
@@ -9,6 +9,8 @@ import org.junit.jupiter.api.TestFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
+import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.controller.ConfiguredApiController.FiltersPrefix.RANGE_FILTER_END_SUFFIX
+import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.controller.ConfiguredApiController.FiltersPrefix.RANGE_FILTER_START_SUFFIX
 import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.ConfiguredApiRepositoryTest.AllMovementPrisoners.movementPrisoner1
 import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.ConfiguredApiRepositoryTest.AllMovementPrisoners.movementPrisoner2
 import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.ConfiguredApiRepositoryTest.AllMovementPrisoners.movementPrisoner3
@@ -57,9 +59,6 @@ class ConfiguredApiRepositoryTest {
 
   @Test
   fun `should return 2 external movements for the selected page 2 and pageSize 2 sorted by date in ascending order`() {
-//    val rangeFilters = mapOf("date.start" to "2023-04-25", "date.end" to "2023-09-10")
-//    val filtersExcludingRange = mapOf("direction" to "In")
-
     val actual = configuredApiRepository.executeQuery(query, emptyMap(), emptyMap(), 2, 2, "date", true)
     Assertions.assertEquals(listOf(movementPrisoner3, movementPrisoner4), actual)
     Assertions.assertEquals(2, actual.size)
@@ -155,43 +154,43 @@ class ConfiguredApiRepositoryTest {
 
   @Test
   fun `should return all the rows on or after the provided start date`() {
-    val actual = configuredApiRepository.executeQuery(query, Collections.singletonMap("date.start", "2023-04-30"), emptyMap(), 1, 10, "date", false)
+    val actual = configuredApiRepository.executeQuery(query, Collections.singletonMap("date$RANGE_FILTER_START_SUFFIX", "2023-04-30"), emptyMap(), 1, 10, "date", false)
     Assertions.assertEquals(listOf(movementPrisoner5, movementPrisoner4, movementPrisoner3), actual)
   }
 
   @Test
   fun `should return all the rows on or before the provided end date`() {
-    val actual = configuredApiRepository.executeQuery(query, Collections.singletonMap("date.end", "2023-04-25"), emptyMap(), 1, 10, "date", false)
+    val actual = configuredApiRepository.executeQuery(query, Collections.singletonMap("date$RANGE_FILTER_END_SUFFIX", "2023-04-25"), emptyMap(), 1, 10, "date", false)
     Assertions.assertEquals(listOf(movementPrisoner2, movementPrisoner1), actual)
   }
 
   @Test
   fun `should return all the rows between the provided start and end dates`() {
-    val actual = configuredApiRepository.executeQuery(query, mapOf("date.start" to "2023-04-25", "date.end" to "2023-05-20"), emptyMap(), 1, 10, "date", false)
+    val actual = configuredApiRepository.executeQuery(query, mapOf("date$RANGE_FILTER_START_SUFFIX" to "2023-04-25", "date$RANGE_FILTER_END_SUFFIX" to "2023-05-20"), emptyMap(), 1, 10, "date", false)
     Assertions.assertEquals(listOf(movementPrisoner5, movementPrisoner4, movementPrisoner3, movementPrisoner2), actual)
   }
 
   @Test
   fun `should return all the rows between the provided start and end dates matching the direction filter`() {
-    val actual = configuredApiRepository.executeQuery(query, mapOf("date.start" to "2023-04-25", "date.end" to "2023-05-20"), mapOf("direction" to "in"), 1, 10, "date", false)
+    val actual = configuredApiRepository.executeQuery(query, mapOf("date$RANGE_FILTER_START_SUFFIX" to "2023-04-25", "date$RANGE_FILTER_END_SUFFIX" to "2023-05-20"), mapOf("direction" to "in"), 1, 10, "date", false)
     Assertions.assertEquals(listOf(movementPrisoner5, movementPrisoner3, movementPrisoner2), actual)
   }
 
   @Test
   fun `should return no rows if the start date is after the latest table date`() {
-    val actual = configuredApiRepository.executeQuery(query, mapOf("date.start" to "2025-01-01"), emptyMap(), 1, 10, "date", false)
+    val actual = configuredApiRepository.executeQuery(query, mapOf("date$RANGE_FILTER_START_SUFFIX" to "2025-01-01"), emptyMap(), 1, 10, "date", false)
     Assertions.assertEquals(emptyList<Map<String, Any>>(), actual)
   }
 
   @Test
   fun `should return no rows if the end date is before the earliest table date`() {
-    val actual = configuredApiRepository.executeQuery(query, mapOf("date.end" to "2015-01-01"), emptyMap(), 1, 10, "date", false)
+    val actual = configuredApiRepository.executeQuery(query, mapOf("date$RANGE_FILTER_END_SUFFIX" to "2015-01-01"), emptyMap(), 1, 10, "date", false)
     Assertions.assertEquals(emptyList<Map<String, Any>>(), actual)
   }
 
   @Test
   fun `should return no rows if the start date is after the end date`() {
-    val actual = configuredApiRepository.executeQuery(query, mapOf("date.start" to "2023-05-01", "date.end" to "2023-04-25"), emptyMap(), 1, 10, "date", false)
+    val actual = configuredApiRepository.executeQuery(query, mapOf("date$RANGE_FILTER_START_SUFFIX" to "2023-05-01", "date$RANGE_FILTER_END_SUFFIX" to "2023-04-25"), emptyMap(), 1, 10, "date", false)
     Assertions.assertEquals(emptyList<Map<String, Any>>(), actual)
   }
 
@@ -233,7 +232,7 @@ class ConfiguredApiRepositoryTest {
       prisonerRepository.save(prisoner9846)
       val actual = configuredApiRepository.executeQuery(
         query,
-        mapOf("date.start" to "2050-06-01", "date.end" to "2050-06-01"),
+        mapOf("date$RANGE_FILTER_START_SUFFIX" to "2050-06-01", "date$RANGE_FILTER_END_SUFFIX" to "2050-06-01"),
         emptyMap(),
         1,
         1,
@@ -268,37 +267,37 @@ class ConfiguredApiRepositoryTest {
 
   @Test
   fun `should return a count of rows with a startDate filter`() {
-    val actual = configuredApiRepository.count(Collections.singletonMap("date.start", "2023-05-01"), emptyMap(), query)
+    val actual = configuredApiRepository.count(Collections.singletonMap("date$RANGE_FILTER_START_SUFFIX", "2023-05-01"), emptyMap(), query)
     Assertions.assertEquals(2, actual)
   }
 
   @Test
   fun `should return a count of rows with an endDate filter`() {
-    val actual = configuredApiRepository.count(Collections.singletonMap("date.end", "2023-01-31"), emptyMap(), query)
+    val actual = configuredApiRepository.count(Collections.singletonMap("date$RANGE_FILTER_END_SUFFIX", "2023-01-31"), emptyMap(), query)
     Assertions.assertEquals(1, actual)
   }
 
   @Test
   fun `should return a count of movements with a startDate and an endDate filter`() {
-    val actual = configuredApiRepository.count(mapOf("date.start" to "2023-04-30", "date.end" to "2023-05-01"), emptyMap(), query)
+    val actual = configuredApiRepository.count(mapOf("date$RANGE_FILTER_START_SUFFIX" to "2023-04-30", "date$RANGE_FILTER_END_SUFFIX" to "2023-05-01"), emptyMap(), query)
     Assertions.assertEquals(2, actual)
   }
 
   @Test
   fun `should return a count of zero with a date start greater than the latest movement date`() {
-    val actual = configuredApiRepository.count(Collections.singletonMap("date.start", "2025-04-30"), emptyMap(), query)
+    val actual = configuredApiRepository.count(Collections.singletonMap("date$RANGE_FILTER_START_SUFFIX", "2025-04-30"), emptyMap(), query)
     Assertions.assertEquals(0, actual)
   }
 
   @Test
   fun `should return a count of zero with a date end less than the earliest movement date`() {
-    val actual = configuredApiRepository.count(Collections.singletonMap("date.end", "2019-04-30"), emptyMap(), query)
+    val actual = configuredApiRepository.count(Collections.singletonMap("date$RANGE_FILTER_END_SUFFIX", "2019-04-30"), emptyMap(), query)
     Assertions.assertEquals(0, actual)
   }
 
   @Test
   fun `should return a count of zero if the start date is after the end date`() {
-    val actual = configuredApiRepository.count(mapOf("date.start" to "2023-04-30", "date.end" to "2019-05-01"), emptyMap(), query)
+    val actual = configuredApiRepository.count(mapOf("date$RANGE_FILTER_START_SUFFIX" to "2023-04-30", "date$RANGE_FILTER_END_SUFFIX" to "2019-05-01"), emptyMap(), query)
     Assertions.assertEquals(0, actual)
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/integration/ConfiguredApiIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/integration/ConfiguredApiIntegrationTest.kt
@@ -9,6 +9,8 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.test.web.reactive.server.expectBodyList
 import org.springframework.web.util.UriBuilder
 import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.controller.ConfiguredApiController.FiltersPrefix.FILTERS_PREFIX
+import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.controller.ConfiguredApiController.FiltersPrefix.RANGE_FILTER_END_SUFFIX
+import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.controller.ConfiguredApiController.FiltersPrefix.RANGE_FILTER_START_SUFFIX
 import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.ConfiguredApiRepositoryTest.AllMovementPrisoners.DATE
 import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.ConfiguredApiRepositoryTest.AllMovementPrisoners.DESTINATION
 import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.ConfiguredApiRepositoryTest.AllMovementPrisoners.DIRECTION
@@ -112,8 +114,8 @@ class ConfiguredApiIntegrationTest : IntegrationTestBase() {
       .uri { uriBuilder: UriBuilder ->
         uriBuilder
           .path("/reports/external-movements/last-month")
-          .queryParam("${FILTERS_PREFIX}date.start", "2023-04-25")
-          .queryParam("${FILTERS_PREFIX}date.end", "2023-05-20")
+          .queryParam("${FILTERS_PREFIX}date$RANGE_FILTER_START_SUFFIX", "2023-04-25")
+          .queryParam("${FILTERS_PREFIX}date$RANGE_FILTER_END_SUFFIX", "2023-05-20")
           .queryParam("${FILTERS_PREFIX}direction", "out")
           .build()
       }
@@ -235,12 +237,12 @@ class ConfiguredApiIntegrationTest : IntegrationTestBase() {
 
   @Test
   fun `Configured API returns 400 for invalid startDate query param`() {
-    requestWithQueryAndAssert400("${FILTERS_PREFIX}date.start", "abc", "/reports/external-movements/last-month")
+    requestWithQueryAndAssert400("${FILTERS_PREFIX}date$RANGE_FILTER_START_SUFFIX", "abc", "/reports/external-movements/last-month")
   }
 
   @Test
   fun `External movements returns 400 for invalid endDate query param`() {
-    requestWithQueryAndAssert400("${FILTERS_PREFIX}date.end", "b", "/reports/external-movements/last-month")
+    requestWithQueryAndAssert400("${FILTERS_PREFIX}date$RANGE_FILTER_END_SUFFIX", "b", "/reports/external-movements/last-month")
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/service/ConfiguredApiServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/service/ConfiguredApiServiceTest.kt
@@ -8,6 +8,8 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.controller.ConfiguredApiController.FiltersPrefix.RANGE_FILTER_END_SUFFIX
+import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.controller.ConfiguredApiController.FiltersPrefix.RANGE_FILTER_START_SUFFIX
 import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.controller.model.Count
 import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.ConfiguredApiRepository
 import uk.gov.justice.digital.hmpps.digitalprisonreportingmi.data.StubbedProductDefinitionRepository
@@ -41,9 +43,9 @@ class ConfiguredApiServiceTest {
   fun `should call the repository with the corresponding arguments and get a list of rows when both range and non range filters are provided`() {
     val reportId = "external-movements"
     val reportVariantId = "last-month"
-    val filters = mapOf("direction" to "in", "date.start" to "2023-04-25", "date.end" to "2023-09-10")
+    val filters = mapOf("direction" to "in", "date$RANGE_FILTER_START_SUFFIX" to "2023-04-25", "date$RANGE_FILTER_END_SUFFIX" to "2023-09-10")
     val filtersExcludingRange = mapOf("direction" to "in")
-    val rangeFilters = mapOf("date.start" to "2023-04-25", "date.end" to "2023-09-10")
+    val rangeFilters = mapOf("date$RANGE_FILTER_START_SUFFIX" to "2023-04-25", "date$RANGE_FILTER_END_SUFFIX" to "2023-09-10")
     val selectedPage = 1L
     val pageSize = 10L
     val sortColumn = "date"
@@ -62,9 +64,9 @@ class ConfiguredApiServiceTest {
   fun `should call the repository with the corresponding arguments and get a count of rows when both range and non range filters are provided`() {
     val reportId = "external-movements"
     val reportVariantId = "last-month"
-    val filters = mapOf("direction" to "in", "date.start" to "2023-04-25", "date.end" to "2023-09-10")
+    val filters = mapOf("direction" to "in", "date$RANGE_FILTER_START_SUFFIX" to "2023-04-25", "date$RANGE_FILTER_END_SUFFIX" to "2023-09-10")
     val filtersExcludingRange = mapOf("direction" to "in")
-    val rangeFilters = mapOf("date.start" to "2023-04-25", "date.end" to "2023-09-10")
+    val rangeFilters = mapOf("date$RANGE_FILTER_START_SUFFIX" to "2023-04-25", "date$RANGE_FILTER_END_SUFFIX" to "2023-09-10")
     val dataSet = stubbedProductDefinitionRepository.getProductDefinitions().first().dataSet.first()
 
     whenever(configuredApiRepository.count(rangeFilters, filtersExcludingRange, dataSet.query)).thenReturn(4)
@@ -79,8 +81,8 @@ class ConfiguredApiServiceTest {
   fun `should call the repository with the corresponding arguments and get a list of rows when only range filters are provided`() {
     val reportId = "external-movements"
     val reportVariantId = "last-month"
-    val filters = mapOf("date.start" to "2023-04-25", "date.end" to "2023-09-10")
-    val rangeFilters = mapOf("date.start" to "2023-04-25", "date.end" to "2023-09-10")
+    val filters = mapOf("date$RANGE_FILTER_START_SUFFIX" to "2023-04-25", "date$RANGE_FILTER_END_SUFFIX" to "2023-09-10")
+    val rangeFilters = mapOf("date$RANGE_FILTER_START_SUFFIX" to "2023-04-25", "date$RANGE_FILTER_END_SUFFIX" to "2023-09-10")
     val selectedPage = 1L
     val pageSize = 10L
     val sortColumn = "date"
@@ -99,8 +101,8 @@ class ConfiguredApiServiceTest {
   fun `should call the repository with the corresponding arguments and get a count of rows when only range filters are provided`() {
     val reportId = "external-movements"
     val reportVariantId = "last-month"
-    val filters = mapOf("date.start" to "2023-04-25", "date.end" to "2023-09-10")
-    val rangeFilters = mapOf("date.start" to "2023-04-25", "date.end" to "2023-09-10")
+    val filters = mapOf("date$RANGE_FILTER_START_SUFFIX" to "2023-04-25", "date$RANGE_FILTER_END_SUFFIX" to "2023-09-10")
+    val rangeFilters = mapOf("date$RANGE_FILTER_START_SUFFIX" to "2023-04-25", "date$RANGE_FILTER_END_SUFFIX" to "2023-09-10")
     val dataSet = stubbedProductDefinitionRepository.getProductDefinitions().first().dataSet.first()
 
     whenever(configuredApiRepository.count(rangeFilters, emptyMap(), dataSet.query)).thenReturn(4)
@@ -150,9 +152,9 @@ class ConfiguredApiServiceTest {
   fun `should call the repository with the corresponding arguments and get a list of rows regardless of the casing of the values of the non range filters`() {
     val reportId = "external-movements"
     val reportVariantId = "last-month"
-    val filters = mapOf("direction" to "In", "date.start" to "2023-04-25", "date.end" to "2023-09-10")
+    val filters = mapOf("direction" to "In", "date$RANGE_FILTER_START_SUFFIX" to "2023-04-25", "date$RANGE_FILTER_END_SUFFIX" to "2023-09-10")
     val filtersExcludingRange = mapOf("direction" to "In")
-    val rangeFilters = mapOf("date.start" to "2023-04-25", "date.end" to "2023-09-10")
+    val rangeFilters = mapOf("date$RANGE_FILTER_START_SUFFIX" to "2023-04-25", "date$RANGE_FILTER_END_SUFFIX" to "2023-09-10")
     val selectedPage = 1L
     val pageSize = 10L
     val sortColumn = "date"
@@ -171,9 +173,9 @@ class ConfiguredApiServiceTest {
   fun `should call the repository with the corresponding arguments and get a count of rows regardless of the casing of the values of the non range filters`() {
     val reportId = "external-movements"
     val reportVariantId = "last-month"
-    val filters = mapOf("direction" to "In", "date.start" to "2023-04-25", "date.end" to "2023-09-10")
+    val filters = mapOf("direction" to "In", "date$RANGE_FILTER_START_SUFFIX" to "2023-04-25", "date$RANGE_FILTER_END_SUFFIX" to "2023-09-10")
     val filtersExcludingRange = mapOf("direction" to "In")
-    val rangeFilters = mapOf("date.start" to "2023-04-25", "date.end" to "2023-09-10")
+    val rangeFilters = mapOf("date$RANGE_FILTER_START_SUFFIX" to "2023-04-25", "date$RANGE_FILTER_END_SUFFIX" to "2023-09-10")
     val dataSet = stubbedProductDefinitionRepository.getProductDefinitions().first().dataSet.first()
 
     whenever(configuredApiRepository.count(rangeFilters, filtersExcludingRange, dataSet.query)).thenReturn(4)
@@ -229,7 +231,7 @@ class ConfiguredApiServiceTest {
   fun `validateAndFetchData should throw an exception for invalid report id`() {
     val reportId = "random report id"
     val reportVariantId = "last-month"
-    val filters = mapOf("direction" to "in", "date.start" to "2023-04-25", "date.end" to "2023-09-10")
+    val filters = mapOf("direction" to "in", "date$RANGE_FILTER_START_SUFFIX" to "2023-04-25", "date$RANGE_FILTER_END_SUFFIX" to "2023-09-10")
     val selectedPage = 1L
     val pageSize = 10L
     val sortColumn = "date"
@@ -246,7 +248,7 @@ class ConfiguredApiServiceTest {
   fun `validateAndCount should throw an exception for invalid report id`() {
     val reportId = "random report id"
     val reportVariantId = "last-month"
-    val filters = mapOf("direction" to "in", "date.start" to "2023-04-25", "date.end" to "2023-09-10")
+    val filters = mapOf("direction" to "in", "date$RANGE_FILTER_START_SUFFIX" to "2023-04-25", "date$RANGE_FILTER_END_SUFFIX" to "2023-09-10")
 
     val e = org.junit.jupiter.api.assertThrows<ValidationException> {
       configuredApiService.validateAndCount(reportId, reportVariantId, filters)
@@ -259,7 +261,7 @@ class ConfiguredApiServiceTest {
   fun `validateAndFetchData should throw an exception for invalid report variant`() {
     val reportId = "external-movements"
     val reportVariantId = "non existent variant"
-    val filters = mapOf("direction" to "in", "date.start" to "2023-04-25", "date.end" to "2023-09-10")
+    val filters = mapOf("direction" to "in", "date$RANGE_FILTER_START_SUFFIX" to "2023-04-25", "date$RANGE_FILTER_END_SUFFIX" to "2023-09-10")
     val selectedPage = 1L
     val pageSize = 10L
     val sortColumn = "date"
@@ -276,7 +278,7 @@ class ConfiguredApiServiceTest {
   fun `validateAndCount should throw an exception for invalid report variant`() {
     val reportId = "external-movements"
     val reportVariantId = "non existent variant"
-    val filters = mapOf("direction" to "in", "date.start" to "2023-04-25", "date.end" to "2023-09-10")
+    val filters = mapOf("direction" to "in", "date$RANGE_FILTER_START_SUFFIX" to "2023-04-25", "date$RANGE_FILTER_END_SUFFIX" to "2023-09-10")
 
     val e = org.junit.jupiter.api.assertThrows<ValidationException> {
       configuredApiService.validateAndCount(reportId, reportVariantId, filters)
@@ -289,7 +291,7 @@ class ConfiguredApiServiceTest {
   fun `validateAndFetchData should throw an exception for invalid sort column`() {
     val reportId = "external-movements"
     val reportVariantId = "last-month"
-    val filters = mapOf("direction" to "in", "date.start" to "2023-04-25", "date.end" to "2023-09-10")
+    val filters = mapOf("direction" to "in", "date$RANGE_FILTER_START_SUFFIX" to "2023-04-25", "date$RANGE_FILTER_END_SUFFIX" to "2023-09-10")
     val selectedPage = 1L
     val pageSize = 10L
     val sortColumn = "abc"
@@ -336,7 +338,7 @@ class ConfiguredApiServiceTest {
   fun `validateAndFetchData should throw an exception when having a valid and an invalid filter`() {
     val reportId = "external-movements"
     val reportVariantId = "last-month"
-    val filters = mapOf("non existent filter" to "blah", "date.start" to "2023-01-01")
+    val filters = mapOf("non existent filter" to "blah", "date$RANGE_FILTER_START_SUFFIX" to "2023-01-01")
     val selectedPage = 1L
     val pageSize = 10L
     val sortColumn = "date"
@@ -353,7 +355,7 @@ class ConfiguredApiServiceTest {
   fun `validateAndCount should throw an exception when having a valid and an invalid filter`() {
     val reportId = "external-movements"
     val reportVariantId = "last-month"
-    val filters = mapOf("non existent filter" to "blah", "date.start" to "2023-01-01")
+    val filters = mapOf("non existent filter" to "blah", "date$RANGE_FILTER_START_SUFFIX" to "2023-01-01")
 
     val e = org.junit.jupiter.api.assertThrows<ValidationException> {
       configuredApiService.validateAndCount(reportId, reportVariantId, filters)
@@ -366,7 +368,7 @@ class ConfiguredApiServiceTest {
   fun `validateAndFetchData should throw an exception when having invalid static options for a filter and a valid range filter`() {
     val reportId = "external-movements"
     val reportVariantId = "last-month"
-    val filters = mapOf("direction" to "randomValue", "date.start" to "2023-01-01")
+    val filters = mapOf("direction" to "randomValue", "date$RANGE_FILTER_START_SUFFIX" to "2023-01-01")
     val selectedPage = 1L
     val pageSize = 10L
     val sortColumn = "date"
@@ -383,7 +385,7 @@ class ConfiguredApiServiceTest {
   fun `validateAndCount should throw an exception when having invalid static options for a filter and a valid range filter`() {
     val reportId = "external-movements"
     val reportVariantId = "last-month"
-    val filters = mapOf("direction" to "randomValue", "date.start" to "2023-01-01")
+    val filters = mapOf("direction" to "randomValue", "date$RANGE_FILTER_START_SUFFIX" to "2023-01-01")
 
     val e = org.junit.jupiter.api.assertThrows<ValidationException> {
       configuredApiService.validateAndCount(reportId, reportVariantId, filters)
@@ -426,7 +428,7 @@ class ConfiguredApiServiceTest {
   fun `validateAndFetchData should throw an exception when having an invalid range filter`() {
     val reportId = "external-movements"
     val reportVariantId = "last-month"
-    val filters = mapOf("date.start" to "abc")
+    val filters = mapOf("date$RANGE_FILTER_START_SUFFIX" to "abc")
     val selectedPage = 1L
     val pageSize = 10L
     val sortColumn = "date"
@@ -443,7 +445,7 @@ class ConfiguredApiServiceTest {
   fun `validateAndCount should throw an exception when having an invalid range filter`() {
     val reportId = "external-movements"
     val reportVariantId = "last-month"
-    val filters = mapOf("date.start" to "abc")
+    val filters = mapOf("date$RANGE_FILTER_START_SUFFIX" to "abc")
 
     val e = org.junit.jupiter.api.assertThrows<ValidationException> {
       configuredApiService.validateAndCount(reportId, reportVariantId, filters)
@@ -456,9 +458,9 @@ class ConfiguredApiServiceTest {
   fun `should call the configuredApiRepository with the default sort column if none is provided`() {
     val reportId = "external-movements"
     val reportVariantId = "last-month"
-    val filters = mapOf("direction" to "in", "date.start" to "2023-04-25", "date.end" to "2023-09-10")
+    val filters = mapOf("direction" to "in", "date$RANGE_FILTER_START_SUFFIX" to "2023-04-25", "date$RANGE_FILTER_END_SUFFIX" to "2023-09-10")
     val filtersExcludingRange = mapOf("direction" to "in")
-    val rangeFilters = mapOf("date.start" to "2023-04-25", "date.end" to "2023-09-10")
+    val rangeFilters = mapOf("date$RANGE_FILTER_START_SUFFIX" to "2023-04-25", "date$RANGE_FILTER_END_SUFFIX" to "2023-09-10")
     val selectedPage = 1L
     val pageSize = 10L
     val sortColumn = "date"


### PR DESCRIPTION
Changes in this PR include:
- Renamed allQueryParams to filters
- Changed the structure of the example to json and added an end date as well.
- Replaced all hardcoded instances of .start and .end with constants and similarly refactored the Swagger descriptions for filters into constants from hardcoded strings.
