### PR TITLE
[DPR2-189] Use time instead of date field in ext. moves.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,7 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-webflux")
   implementation("org.springframework.boot:spring-boot-starter-data-jpa")
   implementation("com.amazon.redshift:redshift-jdbc4-no-awssdk:1.2.45.1069")
-  implementation("uk.gov.justice.service.hmpps:hmpps-digital-prison-reporting-lib:1.0.3")
+  implementation("uk.gov.justice.service.hmpps:hmpps-digital-prison-reporting-lib:1.0.4")
 
   // Security
   implementation("org.springframework.boot:spring-boot-starter-security")

--- a/src/main/resources/definitions.json
+++ b/src/main/resources/definitions.json
@@ -15,7 +15,7 @@
   "dataSet" : [ {
     "id" : "external-movements",
     "name" : "All movements",
-    "query" : "SELECT prisoners.number AS prisonNumber,CONCAT(CONCAT(prisoners.lastname, ', '), substring(prisoners.firstname, 1, 1)) AS name,movements.date,movements.direction,movements.type,movements.origin,movements.origin_code,movements.destination,movements.destination_code,movements.reason\nFROM datamart.domain.movements_movements as movements\nJOIN datamart.domain.prisoner_prisoner as prisoners\nON movements.prisoner = prisoners.id",
+    "query" : "SELECT prisoners.number AS prisonNumber,CONCAT(CONCAT(prisoners.lastname, ', '), substring(prisoners.firstname, 1, 1)) AS name,movements.time AS date,movements.direction,movements.type,movements.origin,movements.origin_code,movements.destination,movements.destination_code,movements.reason\nFROM datamart.domain.movements_movements as movements\nJOIN datamart.domain.prisoner_prisoner as prisoners\nON movements.prisoner = prisoners.id",
     "schema" : {
       "field" : [ {
         "name" : "prisonNumber",
@@ -76,7 +76,7 @@
         "defaultSortColumn" : false
       }, {
         "schemaField" : "$ref:date",
-        "displayName" : "Date",
+        "displayName" : "Date/Time",
         "filter" : {
           "type" : "DateRange",
           "defaultValue" : "today(-1,months) - today()"

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/integration/ConfiguredApiIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingmi/integration/ConfiguredApiIntegrationTest.kt
@@ -305,7 +305,7 @@ class ConfiguredApiIntegrationTest : IntegrationTestBase() {
       4,
       7849,
       LocalDateTime.of(2023, 5, 1, 0, 0, 0),
-      LocalDateTime.of(2023, 5, 1, 15, 19, 0),
+      LocalDateTime.of(2023, 5, 20, 15, 19, 0),
       "Lowestoft (North East Suffolk) Magistrat",
       "LWSTMC",
       "WANDSWORTH (HMP)",
@@ -373,7 +373,7 @@ class ConfiguredApiIntegrationTest : IntegrationTestBase() {
 
     val movementPrisoner3 = mapOf(PRISON_NUMBER to "G3418VR", NAME to "LastName3, F", DATE to "2023-04-30", DIRECTION to "In", TYPE to "Transfer", ORIGIN to "BEDFORD (HMP)", ORIGIN_CODE to "BFI", DESTINATION to "NORTH SEA CAMP (HMP)", DESTINATION_CODE to "NSI", REASON to "Transfer In from Other Establishment")
 
-    val movementPrisoner4 = mapOf(PRISON_NUMBER to "G3411VR", NAME to "LastName5, F", DATE to "2023-05-01", DIRECTION to "Out", TYPE to "Transfer", ORIGIN to "Lowestoft (North East Suffolk) Magistrat", ORIGIN_CODE to "LWSTMC", DESTINATION to "WANDSWORTH (HMP)", DESTINATION_CODE to "WWI", REASON to "Transfer Out to Other Establishment")
+    val movementPrisoner4 = mapOf(PRISON_NUMBER to "G3411VR", NAME to "LastName5, F", DATE to "2023-05-20", DIRECTION to "Out", TYPE to "Transfer", ORIGIN to "Lowestoft (North East Suffolk) Magistrat", ORIGIN_CODE to "LWSTMC", DESTINATION to "WANDSWORTH (HMP)", DESTINATION_CODE to "WWI", REASON to "Transfer Out to Other Establishment")
 
     val movementPrisoner5 = mapOf(PRISON_NUMBER to "G3154UG", NAME to "LastName5, F", DATE to "2023-05-20", DIRECTION to "In", TYPE to "Transfer", ORIGIN to "Bolton Crown Court", ORIGIN_CODE to "BOLTCC", DESTINATION to "HMP HEWELL", DESTINATION_CODE to "HEI", REASON to "Transfer In from Other Establishment")
   }


### PR DESCRIPTION
Also add date-time boundary filtering test, and update library version for filtering tweak.