### PR TITLE
Migrating project to use groups in allowlist

### DIFF
--- a/helm_deploy/hmpps-digital-prison-reporting-mi/Chart.yaml
+++ b/helm_deploy/hmpps-digital-prison-reporting-mi/Chart.yaml
@@ -5,7 +5,7 @@ name: hmpps-digital-prison-reporting-mi
 version: 0.2.0
 dependencies:
   - name: generic-service
-    version: 2.6.3
+    version: "2.8"
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
     version: 1.2.4

--- a/helm_deploy/hmpps-digital-prison-reporting-mi/values.yaml
+++ b/helm_deploy/hmpps-digital-prison-reporting-mi/values.yaml
@@ -1,4 +1,3 @@
----
 generic-service:
   nameOverride: hmpps-digital-prison-reporting-mi
 
@@ -6,12 +5,12 @@ generic-service:
 
   image:
     repository: quay.io/hmpps/hmpps-digital-prison-reporting-mi
-    tag: app_version    # override at deployment time
+    tag: app_version # override at deployment time
     port: 8080
 
   ingress:
     enabled: true
-    host: app-hostname.local    # override per environment
+    host: app-hostname.local # override per environment
     tlsSecretName: hmpps-digital-prison-reporting-mi-cert
 
   # Environment variables to load into the deployment
@@ -38,9 +37,9 @@ generic-service:
       SYSTEM_CLIENT_SECRET: "system_client_secret"
 
   allowlist:
-    cloudplatform-live-1: "35.178.209.113/32"
-    cloudplatform-live-2: "3.8.51.207/32"
-    cloudplatform-live-3: "35.177.252.54/32"
+    cloudplatform-live1-1: 35.178.209.113/32
+    cloudplatform-live1-2: 3.8.51.207/32
+    cloudplatform-live1-3: 35.177.252.54/32
 
 generic-prometheus-alerts:
   targetApplication: hmpps-digital-prison-reporting-mi

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -1,4 +1,3 @@
----
 # Per environment values which override defaults in hmpps-digital-prison-reporting-mi/values.yaml
 
 generic-service:
@@ -15,35 +14,9 @@ generic-service:
     ME_CASELOADS_API_HOST: https://nomis-user-roles-api-dev.prison.service.justice.gov.uk
 
   allowlist:
-    office: "217.33.148.210/32"
-    health-kick: "35.177.252.195/32"
-    petty-france-wifi: "213.121.161.112/28"
-    global-protect: "35.176.93.186/32"
-    mojvpn: "81.134.202.29/32"
-    cloudplatform-live-1: "35.178.209.113/32"
-    cloudplatform-live-2: "3.8.51.207/32"
-    cloudplatform-live-3: "35.177.252.54/32"
-    circleci-1: "3.228.39.90"
-    circleci-2: "18.213.67.41"
-    circleci-3: "34.194.94.201"
-    circleci-4: "34.194.144.202"
-    circleci-5: "34.197.6.234"
-    circleci-6: "35.169.17.173"
-    circleci-7: "35.174.253.146"
-    circleci-8: "52.3.128.216"
-    circleci-9: "52.4.195.249"
-    circleci-10: "52.5.58.121"
-    circleci-11: "52.21.153.129"
-    circleci-12: "52.72.72.233"
-    circleci-13: "54.92.235.88"
-    circleci-14: "54.161.182.76"
-    circleci-15: "54.164.161.41"
-    circleci-16: "54.166.105.113"
-    circleci-17: "54.167.72.230"
-    circleci-18: "54.172.26.132"
-    circleci-19: "54.205.138.102"
-    circleci-20: "54.208.72.234"
-    circleci-21: "54.209.115.53"
+    groups:
+      - circleci
+      - internal
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -1,4 +1,3 @@
----
 # Per environment values which override defaults in hmpps-digital-prison-reporting-mi/values.yaml
 
 generic-service:
@@ -15,35 +14,9 @@ generic-service:
     ME_CASELOADS_API_HOST: https://nomis-user-roles-api-dev.prison.service.justice.gov.uk
 
   allowlist:
-    office: "217.33.148.210/32"
-    health-kick: "35.177.252.195/32"
-    petty-france-wifi: "213.121.161.112/28"
-    global-protect: "35.176.93.186/32"
-    mojvpn: "81.134.202.29/32"
-    cloudplatform-live-1: "35.178.209.113/32"
-    cloudplatform-live-2: "3.8.51.207/32"
-    cloudplatform-live-3: "35.177.252.54/32"
-    circleci-1: "3.228.39.90"
-    circleci-2: "18.213.67.41"
-    circleci-3: "34.194.94.201"
-    circleci-4: "34.194.144.202"
-    circleci-5: "34.197.6.234"
-    circleci-6: "35.169.17.173"
-    circleci-7: "35.174.253.146"
-    circleci-8: "52.3.128.216"
-    circleci-9: "52.4.195.249"
-    circleci-10: "52.5.58.121"
-    circleci-11: "52.21.153.129"
-    circleci-12: "52.72.72.233"
-    circleci-13: "54.92.235.88"
-    circleci-14: "54.161.182.76"
-    circleci-15: "54.164.161.41"
-    circleci-16: "54.166.105.113"
-    circleci-17: "54.167.72.230"
-    circleci-18: "54.172.26.132"
-    circleci-19: "54.205.138.102"
-    circleci-20: "54.208.72.234"
-    circleci-21: "54.209.115.53"
+    groups:
+      - circleci
+      - internal
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts


### PR DESCRIPTION
This PR migrates the project to use groups of IPs in their allowlist.

By referring to groups to IP addresses, we can centralize the definition of groups of ip addresses.
If these lists require changing in the future, we can change the definition once and future deploys across all services will automatically include these new IPs.

3 allowlist(s) have been detected that can be migrated.



## Allowlist: helm_deploy/hmpps-digital-prison-reporting-mi/values.yaml

### New Groups

The effect of applying this PR is as follows:

- The following groups will be applied: ``
- The size of the allowlist defined in this file will change: `3 => 3 (0 removed)`

### Added IPs

The new Group membership will result in the following IPs being added to your allowlist by applying this PR:

  Merging this PR should not result in any additional IP addresses being added to the allowlist.

### Removed IPs

The following IPs have been identified as unnecessary and will be removed by applying this PR:

  **No IPs have been identified for removal**
  

## Allowlist: helm_deploy/values-dev.yaml

### New Groups

The effect of applying this PR is as follows:

- The following groups will be applied: `circleci,internal`
- The size of the allowlist defined in this file will change: `29 => 0 (29 removed)`

### Added IPs

The new Group membership will result in the following IPs being added to your allowlist by applying this PR:

  Merging this PR should not result in any additional IP addresses being added to the allowlist.

### Removed IPs

The following IPs have been identified as unnecessary and will be removed by applying this PR:


- health-kick
  

## Allowlist: helm_deploy/values-test.yaml

### New Groups

The effect of applying this PR is as follows:

- The following groups will be applied: `circleci,internal`
- The size of the allowlist defined in this file will change: `29 => 0 (29 removed)`

### Added IPs

The new Group membership will result in the following IPs being added to your allowlist by applying this PR:

  Merging this PR should not result in any additional IP addresses being added to the allowlist.

### Removed IPs

The following IPs have been identified as unnecessary and will be removed by applying this PR:


- health-kick
  
