### PR TITLE
Dpr2 221 external-movements as git submodule

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,8 @@ jobs:
             - gradle-{{ checksum "build.gradle.kts" }}
             - gradle-
       - run:
+          command: git submodule sync --recursive && git submodule update --recursive --init
+      - run:
           command: ./gradlew check
       - save_cache:
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
             - gradle-{{ checksum "build.gradle.kts" }}
             - gradle-
       - run:
-          command: git submodule sync --recursive && git submodule update --recursive --init
+          command: git submodule sync --recursive && git submodule update --recursive --init && git submodule foreach git pull origin main
       - run:
           command: ./gradlew check
       - save_cache:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "digital-prison-reporting-data-product-definitions"]
+	path = digital-prison-reporting-data-product-definitions
+	url = git@github.com:ministryofjustice/digital-prison-reporting-data-product-definitions.git

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,7 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-webflux")
   implementation("org.springframework.boot:spring-boot-starter-data-jpa")
   implementation("com.amazon.redshift:redshift-jdbc4-no-awssdk:1.2.45.1069")
-  implementation("uk.gov.justice.service.hmpps:hmpps-digital-prison-reporting-lib:1.0.11")
+  implementation("uk.gov.justice.service.hmpps:hmpps-digital-prison-reporting-lib:1.0.12")
 
   // Security
   implementation("org.springframework.boot:spring-boot-starter-security")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,7 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-webflux")
   implementation("org.springframework.boot:spring-boot-starter-data-jpa")
   implementation("com.amazon.redshift:redshift-jdbc4-no-awssdk:1.2.45.1069")
-  implementation("uk.gov.justice.service.hmpps:hmpps-digital-prison-reporting-lib:1.0.10")
+  implementation("uk.gov.justice.service.hmpps:hmpps-digital-prison-reporting-lib:1.0.11")
 
   // Security
   implementation("org.springframework.boot:spring-boot-starter-security")

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -74,4 +74,4 @@ dpr:
     user:
       role: ${AUTHORISED_ROLES}
     definition:
-      location: definitions.json
+      location: external-movements-1.0.0.json

--- a/src/main/resources/external-movements-1.0.0.json
+++ b/src/main/resources/external-movements-1.0.0.json
@@ -1,0 +1,1 @@
+../../../digital-prison-reporting-data-product-definitions/prisons/orphanage/external-movements-1.0.0.json


### PR DESCRIPTION
Include https://github.com/ministryofjustice/digital-prison-reporting-data-product-definitions/blob/main/prisons/orphanage/external-movements-1.0.0.json as a submodule and use it in the reporting mi application.
Note: The external-movements-1.0.0.json file in the resources dir is a symlink of the corresponding file of the git submodule.
Every time the json file in the submodule gets updated so does the respective file in the resources dir.