### PR TITLE
DPR2-729 update lib to fix execute statement error when missing param

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,9 +23,6 @@ RUN ln -snf "/usr/share/zoneinfo/$TZ" /etc/localtime && echo "$TZ" > /etc/timezo
 RUN addgroup --gid 2000 --system appgroup && \
     adduser --uid 2000 --system appuser --gid 2000
 
-RUN apk update && \
-    apk add aws-cli
-
 WORKDIR /app
 COPY --from=builder --chown=appuser:appgroup /app/build/libs/hmpps-digital-prison-reporting-mi*.jar /app/app.jar
 COPY --from=builder --chown=appuser:appgroup /app/build/libs/applicationinsights-agent*.jar /app/agent.jar

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,7 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-webflux")
   implementation("org.springframework.boot:spring-boot-starter-data-jpa")
   implementation("com.amazon.redshift:redshift-jdbc4-no-awssdk:1.2.45.1069")
-  implementation("uk.gov.justice.service.hmpps:hmpps-digital-prison-reporting-lib:3.7.6")
+  implementation("uk.gov.justice.service.hmpps:hmpps-digital-prison-reporting-lib:3.7.8")
 
   // Security
   implementation("org.springframework.boot:spring-boot-starter-security")


### PR DESCRIPTION
These changes update the API library to fix an error when the call to execute statement is missing any parameters.
Also they revert a Dockerfile change which caused the deployment to fail.