### PR TITLE
Dpr 790 change role name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,10 +120,10 @@ workflows:
           name: helm_lint
       - build_multiplatform_docker_job:  
           name: build_docker
-          filters:
-            branches:
-              only:
-                - main
+#          filters:
+#            branches:
+#              only:
+#                - main
           requires:
             - helm_lint
             - validate
@@ -135,10 +135,10 @@ workflows:
           context:
             - hmpps-common-vars
             - hmpps-digital-prison-reporting-mi-dev
-          filters:
-            branches:
-              only:
-                - main
+#          filters:
+#            branches:
+#              only:
+#                - main
           requires:
             - validate
             - build_docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,10 +120,10 @@ workflows:
           name: helm_lint
       - build_multiplatform_docker_job:  
           name: build_docker
-#          filters:
-#            branches:
-#              only:
-#                - main
+          filters:
+            branches:
+              only:
+                - main
           requires:
             - helm_lint
             - validate
@@ -135,10 +135,10 @@ workflows:
           context:
             - hmpps-common-vars
             - hmpps-digital-prison-reporting-mi-dev
-#          filters:
-#            branches:
-#              only:
-#                - main
+          filters:
+            branches:
+              only:
+                - main
           requires:
             - validate
             - build_docker

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,7 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-webflux")
   implementation("org.springframework.boot:spring-boot-starter-data-jpa")
   implementation("com.amazon.redshift:redshift-jdbc4-no-awssdk:1.2.45.1069")
-  implementation("uk.gov.justice.service.hmpps:hmpps-digital-prison-reporting-lib:4.0.0")
+  implementation("uk.gov.justice.service.hmpps:hmpps-digital-prison-reporting-lib:4.1.0")
 
   // Security
   implementation("org.springframework.boot:spring-boot-starter-security")

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -15,7 +15,7 @@ generic-service:
     DEFINITIONS_HOST: http://hmpps-dpr-data-product-definitions-dev.hmpps-digital-prison-reporting-mi-dev.svc.cluster.local
     REDSHIFT_DATA_CLUSTER_ID: dpr-redshift-development
     REDSHIFT_DATA_DB: datamart
-    REDSHIFT_DATA_ROLE_ARN: arn:aws:iam::771283872747:role/dpr-redshift-data-api-cross-role-development
+    REDSHIFT_DATA_ROLE_ARN: arn:aws:iam::771283872747:role/dpr-data-api-cross-account-role
 
   allowlist:
     groups:

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -15,6 +15,7 @@ generic-service:
     DEFINITIONS_HOST: http://hmpps-dpr-data-product-definitions-preprod.hmpps-digital-prison-reporting-mi-preprod.svc.cluster.local
     REDSHIFT_DATA_CLUSTER_ID: dpr-redshift-preproduction
     REDSHIFT_DATA_DB: datamart
+    REDSHIFT_DATA_ROLE_ARN: arn:aws:iam::972272129531:role/dpr-data-api-cross-account-role
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -12,6 +12,7 @@ generic-service:
     DEFINITIONS_HOST: http://hmpps-dpr-data-product-definitions-prod.hmpps-digital-prison-reporting-mi-prod.svc.cluster.local
     REDSHIFT_DATA_CLUSTER_ID: dpr-redshift-production
     REDSHIFT_DATA_DB: datamart
+    REDSHIFT_DATA_ROLE_ARN: arn:aws:iam::004723187462:role/dpr-data-api-cross-account-role
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -14,6 +14,7 @@ generic-service:
     DEFINITIONS_HOST: http://hmpps-dpr-data-product-definitions-test.hmpps-digital-prison-reporting-mi-test.svc.cluster.local
     REDSHIFT_DATA_CLUSTER_ID: dpr-redshift-test
     REDSHIFT_DATA_DB: datamart
+    REDSHIFT_DATA_ROLE_ARN: arn:aws:iam::203591025782:role/dpr-data-api-cross-account-role
 
   allowlist:
     groups:


### PR DESCRIPTION
Changed role name to a generic role name as it is used for both Redshift and Athena.
This is also the same used in terraform.