### PR TITLE
DPR2-945 remove unnecessay env prefixes

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -17,7 +17,6 @@ generic-service:
     REDSHIFT_DATA_DB: datamart
     REDSHIFT_DATA_ROLE_ARN: arn:aws:iam::771283872747:role/dpr-data-api-cross-account-role
     REDSHIFT_DATA_S3_LOCATION: dpr-working-development/reports
-    ATHENA_WORKGROUP_LOCATION: arn:aws:athena:eu-west-2:771283872747:workgroup/dpr-generic-athena-workgroup
 
   allowlist:
     groups:

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -18,7 +18,6 @@ generic-service:
     REDSHIFT_DATA_DB: datamart
     REDSHIFT_DATA_ROLE_ARN: arn:aws:iam::972272129531:role/dpr-data-api-cross-account-role
     REDSHIFT_DATA_S3_LOCATION: dpr-working-preproduction/reports
-    ATHENA_WORKGROUP_LOCATION: arn:aws:athena:eu-west-2:972272129531:workgroup/dpr-generic-athena-workgroup
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -15,7 +15,6 @@ generic-service:
     REDSHIFT_DATA_DB: datamart
     REDSHIFT_DATA_ROLE_ARN: arn:aws:iam::004723187462:role/dpr-data-api-cross-account-role
     REDSHIFT_DATA_S3_LOCATION: dpr-working-production/reports
-    ATHENA_WORKGROUP_LOCATION: arn:aws:athena:eu-west-2:004723187462:workgroup/dpr-generic-athena-workgroup
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -17,7 +17,6 @@ generic-service:
     REDSHIFT_DATA_DB: datamart
     REDSHIFT_DATA_ROLE_ARN: arn:aws:iam::203591025782:role/dpr-data-api-cross-account-role
     REDSHIFT_DATA_S3_LOCATION: dpr-working-test/reports
-    ATHENA_WORKGROUP_LOCATION: arn:aws:athena:eu-west-2:203591025782:workgroup/dpr-generic-athena-workgroup
 
   allowlist:
     groups:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -86,4 +86,4 @@ dpr:
       rolearn: ${REDSHIFT_DATA_ROLE_ARN}
       rolesessionname: dpr-cross-account-role-session
       s3location: ${REDSHIFT_DATA_S3_LOCATION}
-      athenaworkgroup: ${ATHENA_WORKGROUP_LOCATION}
+      athenaworkgroup: dpr-generic-athena-workgroup


### PR DESCRIPTION
Removed the full arn names from the workgroup name as the Java SDK config requires only the name itself.