### PR TITLE
DPR2-1976 fix github workflow to bump library version

### DIFF
--- a/.github/workflows/bump-lib-version.yml
+++ b/.github/workflows/bump-lib-version.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Get library version
         id: get-version
         run: |
-          CURRENT_VERSION=$(curl -s --request GET https://s01.oss.sonatype.org/service/local/repositories/releases/content/uk/gov/justice/service/hmpps/hmpps-digital-prison-reporting-lib/maven-metadata.xml | grep "latest" | grep -oP "\d+\.\d+\.\d+")
+          CURRENT_VERSION=$(curl -s --request GET https://repo1.maven.org/maven2/uk/gov/justice/service/hmpps/hmpps-digital-prison-reporting-lib/maven-metadata.xml | grep -oP '(?<=<version>)[^<]+' | grep -v -e '2024-02-27' -e '2024-02-28' | tail -n1)
           echo "Current version: $CURRENT_VERSION"
           echo "current_version=$CURRENT_VERSION" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
The following URL is now stale: https://s01.oss.sonatype.org/service/local/repositories/releases/content/uk/gov/justice/service/hmpps/hmpps-digital-prison-reporting-lib/maven-metadata.xml
This is since we have migrated from s01.oss.sonatype.org to using the[ OSSRH Staging repository for publishing](https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/).
So now the up to date published versions can be found here:
https://repo1.maven.org/maven2/uk/gov/justice/service/hmpps/hmpps-digital-prison-reporting-lib/maven-metadata.xml
The following two versions were mistakenly published in the past and due to their high number are considered latest in the xml. Therefore, they are skipped in the script.
`2024-02-27`
`2024-02-28`
