### PR TITLE
Dont need to sha pin internal workflows, runner is fussy about allowe…

### DIFF
--- a/.github/workflows/security_owasp.yml
+++ b/.github/workflows/security_owasp.yml
@@ -11,7 +11,7 @@ jobs:
       actions: read
       security-events: write
     name: Kotlin security OWASP dependency check
-    uses: ministryofjustice/hmpps-github-actions/.github/workflows/security_owasp.yml@95c48db64a6d50acd1f8f8a0f93d1019727e5b4d
+    uses: ministryofjustice/hmpps-github-actions/.github/workflows/security_owasp.yml@v2
     with:
       channel_id: ${{ vars.SECURITY_ALERTS_SLACK_CHANNEL_ID || 'NO_SLACK' }}
       nvd_feed_version: "2"


### PR DESCRIPTION
…d versions